### PR TITLE
[송현우] swagger api Oauth2.0 인증 및 JWT토큰 가드 적용

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/class-transformer": "^0.4.0",
         "@nestjs/class-validator": "^0.13.4",
         "@nestjs/common": "^10.0.0",
+        "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/passport": "^10.0.2",
@@ -1729,6 +1730,29 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.1.1.tgz",
+      "integrity": "sha512-qu5QlNiJdqQtOsnB6lx4JCXPQ96jkKUsOGd+JXfXwqJqZcOSAq6heNFg0opW4pq4J/VZoNwoo87TNnx9wthnqQ==",
+      "dependencies": {
+        "dotenv": "16.3.1",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nestjs/core": {
@@ -4492,6 +4516,14 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/eastasianwidth": {
@@ -12093,6 +12125,24 @@
         "uid": "2.0.2"
       }
     },
+    "@nestjs/config": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.1.1.tgz",
+      "integrity": "sha512-qu5QlNiJdqQtOsnB6lx4JCXPQ96jkKUsOGd+JXfXwqJqZcOSAq6heNFg0opW4pq4J/VZoNwoo87TNnx9wthnqQ==",
+      "requires": {
+        "dotenv": "16.3.1",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
+      }
+    },
     "@nestjs/core": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.8.tgz",
@@ -14124,6 +14174,11 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+    },
+    "dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
     },
     "eastasianwidth": {
       "version": "0.2.0",

--- a/back/package.json
+++ b/back/package.json
@@ -23,6 +23,7 @@
     "@nestjs/class-transformer": "^0.4.0",
     "@nestjs/class-validator": "^0.13.4",
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.2",

--- a/back/src/app.module.ts
+++ b/back/src/app.module.ts
@@ -5,9 +5,15 @@ import { AppService } from './app.service';
 import { AuthModule } from './modules/auth/auth.module';
 import { SnowballModule } from './modules/snowball/snowball.module';
 import typeOrmConfig from './config/ormconfig';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeOrmConfig), AuthModule, SnowballModule],
+  imports: [
+    TypeOrmModule.forRoot(typeOrmConfig),
+    ConfigModule.forRoot({ isGlobal: true }),
+    AuthModule,
+    SnowballModule
+  ],
   controllers: [AppController],
   providers: [AppService]
 })

--- a/back/src/modules/auth/auth.controller.ts
+++ b/back/src/modules/auth/auth.controller.ts
@@ -37,8 +37,8 @@ export class AuthController {
     description: 'Internal Server Error'
   })
   async googleLoginCallback(@Req() req): Promise<ResInfoDto> {
-    const profile: string = req.user.profile;
-    const result = this.authService.createInfo(profile);
+    const userInfo = req.user;
+    const result = this.authService.createInfo(userInfo);
     return result;
   }
 
@@ -71,8 +71,8 @@ export class AuthController {
     description: 'Internal Server Error'
   })
   async naverLoginCallBack(@Req() req): Promise<ResInfoDto> {
-    const profile: string = req.user.profile;
-    const result = this.authService.createInfo(profile);
+    const userInfo = req.user;
+    const result = this.authService.createInfo(userInfo);
     return result;
   }
 

--- a/back/src/modules/auth/auth.guard.ts
+++ b/back/src/modules/auth/auth.guard.ts
@@ -32,6 +32,6 @@ export class JWTGuard implements CanActivate {
 
   private extractTokenFromHeader(@Req() req: Request): string | undefined {
     const [type, token] = req.headers.authorization?.split(' ') ?? [];
-    return type === 'Bearer' ? token : null;
+    return type === 'Bearer' ? token : undefined;
   }
 }

--- a/back/src/modules/auth/auth.module.ts
+++ b/back/src/modules/auth/auth.module.ts
@@ -11,6 +11,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SnowballEntity } from '../snowball/entity/snowball.entity';
 import { UserEntity } from './entity/user.entity';
 import { SnowballDecorationEntity } from '../snowball/entity/snowball-decoration.entity';
+import { JWTGuard } from './auth.guard';
+import { ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -20,9 +23,13 @@ import { SnowballDecorationEntity } from '../snowball/entity/snowball-decoration
       SnowballDecorationEntity
     ]),
     PassportModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: '300s' }
+    ConfigModule.forRoot({ isGlobal: true }),
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '300s' }
+      })
     })
   ],
   providers: [
@@ -30,8 +37,10 @@ import { SnowballDecorationEntity } from '../snowball/entity/snowball-decoration
     NaverAuthStrategy,
     KakaoAuthStrategy,
     AuthService,
-    SnowballService
+    SnowballService,
+    JWTGuard
   ],
-  controllers: [AuthController]
+  controllers: [AuthController],
+  exports: [JWTGuard]
 })
 export class AuthModule {}

--- a/back/src/modules/auth/auth.module.ts
+++ b/back/src/modules/auth/auth.module.ts
@@ -23,7 +23,6 @@ import { ConfigModule } from '@nestjs/config';
       SnowballDecorationEntity
     ]),
     PassportModule,
-    ConfigModule.forRoot({ isGlobal: true }),
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({

--- a/back/src/modules/auth/dto/user.dto.ts
+++ b/back/src/modules/auth/dto/user.dto.ts
@@ -41,4 +41,3 @@ export class UserDto {
   @ApiProperty({ type: Number, description: '메시지 갯수' })
   readonly message_count: number;
 }
-

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -5,7 +5,8 @@ import {
   Delete,
   Body,
   Param,
-  HttpCode
+  HttpCode,
+  UseGuards
 } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
@@ -19,6 +20,7 @@ import {
 } from '@nestjs/swagger';
 import { ResCreateMessageDto } from './dto/response/res-create-message.dto';
 import { MessageDto } from './dto/message.dto';
+import { JWTGuard } from '../auth/auth.guard';
 
 @ApiTags('Message API')
 @Controller('message')
@@ -52,6 +54,7 @@ export class MessageController {
     return resCreateMessage;
   }
 
+  @UseGuards(JWTGuard)
   @ApiBearerAuth('jwt-token')
   @Delete(':message_id')
   @HttpCode(204)
@@ -68,6 +71,7 @@ export class MessageController {
     await this.messageService.deleteMessage(deleteMessageDto);
   }
 
+  @UseGuards(JWTGuard)
   @ApiBearerAuth('jwt-token')
   @Get('/:user_id')
   @HttpCode(200)

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -10,7 +10,13 @@ import {
 import { MessageService } from './message.service';
 import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
 import { ReqDeleteMessageDto } from './dto/request/req-delete-message.dto';
-import { ApiBody, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth
+} from '@nestjs/swagger';
 import { ResCreateMessageDto } from './dto/response/res-create-message.dto';
 import { MessageDto } from './dto/message.dto';
 
@@ -46,6 +52,7 @@ export class MessageController {
     return resCreateMessage;
   }
 
+  @ApiBearerAuth('jwt-token')
   @Delete(':message_id')
   @HttpCode(204)
   @ApiOperation({
@@ -61,6 +68,7 @@ export class MessageController {
     await this.messageService.deleteMessage(deleteMessageDto);
   }
 
+  @ApiBearerAuth('jwt-token')
   @Get('/:user_id')
   @HttpCode(200)
   @ApiOperation({

--- a/back/src/modules/message/message.module.ts
+++ b/back/src/modules/message/message.module.ts
@@ -5,9 +5,16 @@ import { MessageService } from './message.service';
 import { MessageEntity } from './entity/message.entity';
 import { UserEntity } from '../auth/entity/user.entity';
 import { SnowballEntity } from '../snowball/entity/snowball.entity';
+import { AuthModule } from '../auth/auth.module';
+import { JwtModule } from '@nestjs/jwt';
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserEntity, SnowballEntity, MessageEntity])
+    TypeOrmModule.forFeature([UserEntity, SnowballEntity, MessageEntity]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: '300s' }
+    }),
+    AuthModule
   ],
   controllers: [MessageController],
   providers: [MessageService]

--- a/back/src/modules/snowball/dto/request/req-create-snowball.dto.ts
+++ b/back/src/modules/snowball/dto/request/req-create-snowball.dto.ts
@@ -35,5 +35,5 @@ export class ReqCreateSnowballDto {
     type: Boolean,
     description: '스노우볼 속 메시지들 비공개 여부'
   })
-  readonly message_private: boolean;
+  readonly is_message_private: boolean;
 }

--- a/back/src/modules/snowball/dto/request/req-update-decoration.dto.ts
+++ b/back/src/modules/snowball/dto/request/req-update-decoration.dto.ts
@@ -4,11 +4,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { DecorationSnowballDto } from '../decoration-snowball.dto';
 
 export class ReqUpdateSnowballDecoDto {
-  // @IsNotEmpty()
-  // @IsNumber()
-  // @ApiProperty({ type: Number, description: '스노우볼 id' })
-  // readonly snowball_id: number;
-
   @IsNotEmpty()
   @ValidateNested({ each: true })
   @Type(() => DecorationSnowballDto)

--- a/back/src/modules/snowball/dto/request/req-update-snowball.dto.ts
+++ b/back/src/modules/snowball/dto/request/req-update-snowball.dto.ts
@@ -13,5 +13,5 @@ export class ReqUpdateSnowballDto {
     type: Boolean,
     description: '스노우볼 속 메시지들 비공개 여부'
   })
-  readonly message_private: boolean;
+  readonly is_message_private: boolean;
 }

--- a/back/src/modules/snowball/dto/response/res-update-snowball.dto.ts
+++ b/back/src/modules/snowball/dto/response/res-update-snowball.dto.ts
@@ -15,5 +15,5 @@ export class ResUpdateSnowballDto {
     type: Boolean,
     description: '변경된 스노우볼 속 메시지들 비공개 여부'
   })
-  readonly message_private: boolean;
+  readonly is_message_private: boolean;
 }

--- a/back/src/modules/snowball/dto/snowball.dto.ts
+++ b/back/src/modules/snowball/dto/snowball.dto.ts
@@ -33,7 +33,7 @@ export class SnowballDto {
     type: Boolean,
     description: '스노우볼 속 메시지들 비공개 여부'
   })
-  readonly message_private: boolean;
+  readonly is_message_private: boolean;
 
   @IsNotEmpty()
   @ValidateNested({ each: true })

--- a/back/src/modules/snowball/snowball.controller.ts
+++ b/back/src/modules/snowball/snowball.controller.ts
@@ -5,7 +5,8 @@ import {
   Body,
   Param,
   Get,
-  HttpCode
+  HttpCode,
+  UseGuards
 } from '@nestjs/common';
 import { SnowballService } from './snowball.service';
 import {
@@ -13,7 +14,8 @@ import {
   ApiTags,
   ApiOperation,
   ApiCreatedResponse,
-  ApiResponse
+  ApiResponse,
+  ApiBearerAuth
 } from '@nestjs/swagger';
 import { ReqCreateSnowballDto } from './dto/request/req-create-snowball.dto';
 import { ReqUpdateSnowballDto } from './dto/request/req-update-snowball.dto';
@@ -21,8 +23,11 @@ import { SnowballDto } from './dto/snowball.dto';
 import { ResUpdateSnowballDto } from './dto/response/res-update-snowball.dto';
 import { ReqUpdateSnowballDecoDto } from './dto/request/req-update-decoration.dto';
 import { ResUpdateSnowballDecoDto } from './dto/response/res-update-decoration.dto';
+import { JWTGuard } from '../auth/auth.guard';
 
 @ApiTags('Snowball API')
+@UseGuards(JWTGuard)
+@ApiBearerAuth('jwt-token')
 @Controller('snowball')
 export class SnowballController {
   constructor(private readonly snowballService: SnowballService) {}

--- a/back/src/modules/snowball/snowball.module.ts
+++ b/back/src/modules/snowball/snowball.module.ts
@@ -6,6 +6,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SnowballEntity } from './entity/snowball.entity';
 import { MessageEntity } from '../message/entity/message.entity';
 import { SnowballDecorationEntity } from './entity/snowball-decoration.entity';
+import { AuthModule } from '../auth/auth.module';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
   imports: [
@@ -14,7 +16,12 @@ import { SnowballDecorationEntity } from './entity/snowball-decoration.entity';
       MessageEntity,
       SnowballDecorationEntity
     ]),
-    MessageModule
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: '300s' }
+    }),
+    MessageModule,
+    AuthModule
   ],
   controllers: [SnowballController],
   providers: [SnowballService]

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -26,7 +26,7 @@ export class SnowballService {
     const snowball = this.snowballRepository.create({
       user_id: createSnowballDto.user_id,
       title: createSnowballDto.title,
-      message_private: createSnowballDto.message_private ? new Date() : null
+      message_private: createSnowballDto.is_message_private ? new Date() : null
     });
     const savedSnowball = await this.snowballRepository.save(snowball);
 
@@ -39,7 +39,7 @@ export class SnowballService {
       id: savedSnowball.id,
       uuid: savedSnowball.snowball_uuid,
       title: savedSnowball.title,
-      message_private: savedSnowball.message_private === null ? false : true,
+      is_message_private: savedSnowball.message_private === null ? false : true,
       deco_list: decoList,
       message_list: []
     };
@@ -91,14 +91,14 @@ export class SnowballService {
     updateSnowballDto: ReqUpdateSnowballDto,
     snowball_id: number
   ): Promise<ResUpdateSnowballDto> {
-    const { title, message_private } = updateSnowballDto;
+    const { title, is_message_private } = updateSnowballDto;
 
     const updateResult = await this.snowballRepository
       .createQueryBuilder()
       .update(SnowballEntity)
       .set({
         title,
-        message_private: message_private ? new Date() : null
+        message_private: is_message_private ? new Date() : null
       })
       .where('id = :id', { id: snowball_id })
       .execute();
@@ -111,7 +111,7 @@ export class SnowballService {
     const resUpdateSnowballDto: ResUpdateSnowballDto = {
       snowball_id,
       title,
-      message_private
+      is_message_private
     };
 
     return resUpdateSnowballDto;
@@ -133,7 +133,7 @@ export class SnowballService {
       id: snowball.id,
       uuid: snowball.snowball_uuid,
       title: snowball.title,
-      message_private: snowball.message_private ? true : false,
+      is_message_private: snowball.message_private ? true : false,
       deco_list: snowball.decorations,
       message_list: snowball.messages.map(message => ({
         id: message.id,

--- a/back/src/util/swagger.ts
+++ b/back/src/util/swagger.ts
@@ -17,6 +17,17 @@ export function setupSwagger(app: INestApplication): void {
     .setDescription('The SSOCK API description')
     .setVersion('1.0')
     .addTag('ssock')
+    .addOAuth2({
+      type: 'oauth2',
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'http://www.mysnowball.kr/auth/google',
+          scopes: {
+            profile: 'profile'
+          }
+        }
+      }
+    })
     .addBearerAuth(
       {
         type: 'http',
@@ -25,7 +36,7 @@ export function setupSwagger(app: INestApplication): void {
         name: 'JWT',
         in: 'header'
       },
-      'token'
+      'jwt-token'
     )
     .build();
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
## 💡 완료된 기능
- [x] boolean 네이밍 수정
- [x] swagger Oauth2.0 인증 구현
- [x] JWTGuards() 등록 & swagger Bearer인증 설정

- @useGuard(JWTGuard)를 라우터/컨트롤러별로 등록하니, swagger에서 api test를 진행할 수 없는 문제가 발생했다
- 이를 해결하기 위해 swagger에서 Oauth(google)인증을 보낼 수 있도록 설정했다
- 인증에 성공하면 jwt token을 리턴해준다. 이를 복사하여 authorize의 jwt-token 입력칸에 입력하면 swagger에서 request시 자동으로 헤더에 bareer타입의 토큰이 들어간다
- 실제 서비스 동작 방식과 동일하게 swagger에서 테스트할 수 있다

- 트러블 슈팅 (error : secretOrPrivateKey must have a value)
  - this.jwtService.sign(payload); 이 부분에서 해당 에러 발생
  - .env를 읽어오는 작업은 비동기적임. 이로 인해 JwtModule.register에서 process.env.JWT_SECRET을 참조할 때까지 .env를 다 못 읽어오는 일이 발생하는 것으로 보임
  - JwtModule를 등록할 때, register가 아닌 registerAsync라는 메소드에 ConfigService를 주입해두어 .env를 읽어올 때까지 secret을 등록하는 작업을 유예시킴
  - 이전에 ormconfig에서 비슷한 에러를 겪었을 때, dotenv.config() 위치를 옮기는 식으로 해결했는데 위와 같은 방식으로 forRootAsync을 활용하도록 변경하면 좋을 것 같음!

## 📷 완료된 기능 사진
### Guard를 등록하니 swagger가 막힘
![guard설정](https://github.com/boostcampwm2023/web11-SSOCK/assets/83938394/0a6bc137-347e-403f-807c-c5ef4433350d)
### Oauth2.0 인증
![auth인증](https://github.com/boostcampwm2023/web11-SSOCK/assets/83938394/959592f3-0cd2-40b0-8067-b49fd3576c90)
### 성공 시 jwt-token을 등록
![jwt token 등록](https://github.com/boostcampwm2023/web11-SSOCK/assets/83938394/20211bf0-f0e1-4195-b035-f7771df81cd7)
### 제대로 응답이 오는 것을 확인
![성공! -H넣음](https://github.com/boostcampwm2023/web11-SSOCK/assets/83938394/02de7e7c-93f5-484c-a978-aa28b27a2508)