### PR TITLE
[최진수] : 멘토님 리뷰반영해서 API 수정

### DIFF
--- a/back/src/modules/auth/entity/user.entity.ts
+++ b/back/src/modules/auth/entity/user.entity.ts
@@ -6,6 +6,7 @@ import {
   CreateDateColumn
 } from 'typeorm';
 import { SnowballEntity } from '../../snowball/entity/snowball.entity';
+import { MessageEntity } from 'src/modules/message/entity/message.entity';
 
 @Entity({ name: 'user' })
 export class UserEntity {
@@ -26,4 +27,7 @@ export class UserEntity {
 
   @OneToMany(() => SnowballEntity, snowball => snowball.user)
   snowballs: SnowballEntity[];
+
+  @OneToMany(() => MessageEntity, message => message.user)
+  messages: MessageEntity[];
 }

--- a/back/src/modules/message/dto/request/req-delete-message.dto.ts
+++ b/back/src/modules/message/dto/request/req-delete-message.dto.ts
@@ -1,9 +1,0 @@
-import { IsNumber, IsNotEmpty } from '@nestjs/class-validator';
-import { ApiProperty } from '@nestjs/swagger';
-
-export class ReqDeleteMessageDto {
-  @IsNumber()
-  @IsNotEmpty()
-  @ApiProperty({ type: Number, description: '메세지 id' })
-  readonly message_id: number;
-}

--- a/back/src/modules/message/entity/letter.entity.ts
+++ b/back/src/modules/message/entity/letter.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { MessageEntity } from './message.entity';
 
-@Entity()
+@Entity({ name: 'letter_prefix' })
 export class LetterEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/back/src/modules/message/entity/letter.entity.ts
+++ b/back/src/modules/message/entity/letter.entity.ts
@@ -1,0 +1,11 @@
+import { Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { MessageEntity } from './message.entity';
+
+@Entity()
+export class LetterEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @OneToMany(() => MessageEntity, message => message.letter_id)
+  messages: MessageEntity[];
+}

--- a/back/src/modules/message/entity/message.entity.ts
+++ b/back/src/modules/message/entity/message.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { SnowballEntity } from 'src/modules/snowball/entity/snowball.entity';
 import { UserEntity } from 'src/modules/auth/entity/user.entity';
+import { LetterEntity } from './letter.entity';
 
 @Entity({ synchronize: true, name: 'message' })
 export class MessageEntity {
@@ -51,4 +52,9 @@ export class MessageEntity {
   @ManyToOne(() => UserEntity, user => user.messages)
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
+
+  //many to one relation letter_id with id in LetterEntity in letter.entity.ts
+  @ManyToOne(() => LetterEntity, letter => letter.messages)
+  @JoinColumn({ name: 'letter_id' })
+  letter: LetterEntity;
 }

--- a/back/src/modules/message/entity/message.entity.ts
+++ b/back/src/modules/message/entity/message.entity.ts
@@ -7,11 +7,15 @@ import {
   JoinColumn
 } from 'typeorm';
 import { SnowballEntity } from 'src/modules/snowball/entity/snowball.entity';
+import { UserEntity } from 'src/modules/auth/entity/user.entity';
 
 @Entity({ synchronize: true, name: 'message' })
 export class MessageEntity {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column()
+  user_id: number;
 
   @Column()
   snowball_id: number;
@@ -40,4 +44,8 @@ export class MessageEntity {
   @ManyToOne(() => SnowballEntity, snowball => snowball.messages)
   @JoinColumn({ name: 'snowball_id' })
   snowball: SnowballEntity;
+
+  @ManyToOne(() => UserEntity, user => user.messages)
+  @JoinColumn({ name: 'user_id' })
+  user: UserEntity;
 }

--- a/back/src/modules/message/entity/message.entity.ts
+++ b/back/src/modules/message/entity/message.entity.ts
@@ -35,6 +35,9 @@ export class MessageEntity {
   @Column({ length: 16 })
   sender: string;
 
+  @Column({ type: 'boolean', default: false })
+  is_deleted: boolean;
+
   @CreateDateColumn({ nullable: true, default: null })
   opened: Date | null;
 

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -7,7 +7,8 @@ import {
   Param,
   HttpCode,
   UseGuards,
-  Put
+  Put,
+  Req
 } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
@@ -78,24 +79,23 @@ export class MessageController {
 
   @UseGuards(JWTGuard)
   @ApiBearerAuth('jwt-token')
-  @Get('/:user_id')
+  @Get('/')
   @HttpCode(200)
   @ApiOperation({
     summary: '메세지 조회 API',
-    description: '모든 메세지를 조회합니다'
+    description:
+      '모든 메세지를 조회합니다. JWT 토큰안에 user_id를 이용해 조회합니다.'
   })
   @ApiResponse({
     status: 200,
-    type: MessageDto
+    type: [MessageDto]
   })
   @ApiResponse({
     status: 500,
     description: 'Find Fail'
   })
-  async getAllMessages(
-    @Param('user_id') user_id: number
-  ): Promise<MessageDto[]> {
-    const messages = await this.messageService.getAllMessages(user_id);
+  async getAllMessages(@Req() req: any): Promise<MessageDto[]> {
+    const messages = await this.messageService.getAllMessages(req.user);
     return messages;
   }
 

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -6,7 +6,8 @@ import {
   Body,
   Param,
   HttpCode,
-  UseGuards
+  UseGuards,
+  Put
 } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
@@ -16,7 +17,11 @@ import {
   ApiTags,
   ApiOperation,
   ApiResponse,
-  ApiBearerAuth
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiConflictResponse,
+  ApiBadRequestResponse,
+  ApiInternalServerErrorResponse
 } from '@nestjs/swagger';
 import { ResCreateMessageDto } from './dto/response/res-create-message.dto';
 import { MessageDto } from './dto/message.dto';
@@ -92,5 +97,35 @@ export class MessageController {
   ): Promise<MessageDto[]> {
     const messages = await this.messageService.getAllMessages(user_id);
     return messages;
+  }
+
+  @UseGuards(JWTGuard)
+  @ApiBearerAuth('jwt-token')
+  @Put('/open/:message_id')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: '메세지 오픈 처리',
+    description: '메시지를 오픈 처리합니다.'
+  })
+  @ApiResponse({
+    status: 200,
+    type: MessageDto
+  })
+  @ApiBadRequestResponse({
+    description: '잘못된 요청입니다.'
+  })
+  @ApiNotFoundResponse({
+    description: '해당 메시지가 존재하지 않습니다.'
+  })
+  @ApiConflictResponse({
+    description: '이미 오픈된 메시지입니다.'
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버측 오류'
+  })
+  async openMessage(
+    @Param('message_id') message_id: number
+  ): Promise<MessageDto> {
+    return await this.messageService.openMessage(message_id);
   }
 }

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -110,7 +110,7 @@ export class MessageController {
 
   @UseGuards(JWTGuard)
   @ApiBearerAuth('jwt-token')
-  @Put('/open/:message_id')
+  @Put('/:message_id/open')
   @HttpCode(200)
   @ApiOperation({
     summary: '메세지 오픈 처리',

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -12,7 +12,6 @@ import {
 } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
-import { ReqDeleteMessageDto } from './dto/request/req-delete-message.dto';
 import {
   ApiBody,
   ApiTags,
@@ -22,7 +21,9 @@ import {
   ApiNotFoundResponse,
   ApiConflictResponse,
   ApiBadRequestResponse,
-  ApiInternalServerErrorResponse
+  ApiInternalServerErrorResponse,
+  ApiGoneResponse,
+  ApiUnauthorizedResponse
 } from '@nestjs/swagger';
 import { ResCreateMessageDto } from './dto/response/res-create-message.dto';
 import { MessageDto } from './dto/message.dto';
@@ -68,13 +69,21 @@ export class MessageController {
     summary: '메세지 삭제 API',
     description: '스노우볼에서 특정 메세지를 삭제합니다.'
   })
-  @ApiResponse({ status: 204, description: 'No Content' })
   @ApiResponse({
-    status: 500,
-    description: 'Delete Fail'
+    status: 204,
+    description: '해당 메시지가 성공적으로 지워졌음'
   })
-  async deleteMessage(@Param() deleteMessageDto: ReqDeleteMessageDto) {
-    await this.messageService.deleteMessage(deleteMessageDto);
+  @ApiGoneResponse({
+    description: '이미 삭제된 메시지입니다.'
+  })
+  @ApiUnauthorizedResponse({
+    description: '로그인이 필요합니다.'
+  })
+  async deleteMessage(
+    @Req() req: any,
+    @Param('message_id') message_id: number
+  ) {
+    await this.messageService.deleteMessage(req.user, message_id);
   }
 
   @UseGuards(JWTGuard)

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
@@ -83,5 +88,31 @@ export class MessageService {
       };
     });
     return messagesDto;
+  }
+
+  async openMessage(message_id: number): Promise<MessageDto> {
+    try {
+      const message = await this.messageRepository.findOne({
+        where: { id: message_id }
+      });
+      if (!message) {
+        throw new NotFoundException(
+          `${message_id} 메시지를 찾을 수 없었습니다.`
+        );
+      }
+      if (message.opened !== null) {
+        throw new ConflictException(
+          `${message_id} 메시지는 이미 열려있습니다.`
+        );
+      }
+      const date = new Date();
+      await this.messageRepository.update(message_id, { opened: date });
+      return {
+        ...message,
+        opened: date
+      };
+    } catch (err) {
+      throw new InternalServerErrorException('서버측 오류');
+    }
   }
 }

--- a/back/src/modules/snowball/entity/decoration-prefix.entity.ts
+++ b/back/src/modules/snowball/entity/decoration-prefix.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { SnowballDecorationEntity } from './snowball-decoration.entity';
 
-@Entity()
+@Entity({ name: 'decoration_prefix' })
 export class DecorationPrefixEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/back/src/modules/snowball/entity/decoration-prefix.entity.ts
+++ b/back/src/modules/snowball/entity/decoration-prefix.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { SnowballDecorationEntity } from './snowball-decoration.entity';
+
+@Entity()
+export class DecorationPrefixEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @OneToMany(
+    () => SnowballDecorationEntity,
+    snowballDecoration => snowballDecoration.decoration_id
+  )
+  decorations: SnowballDecorationEntity[];
+}

--- a/back/src/modules/snowball/entity/snowball-decoration.entity.ts
+++ b/back/src/modules/snowball/entity/snowball-decoration.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn
 } from 'typeorm';
 import { SnowballEntity } from './snowball.entity';
+import { DecorationPrefixEntity } from './decoration-prefix.entity';
 
 @Entity({ name: 'snowball_decoration' })
 export class SnowballDecorationEntity {
@@ -27,4 +28,11 @@ export class SnowballDecorationEntity {
   @ManyToOne(() => SnowballEntity, snowball => snowball.decorations)
   @JoinColumn({ name: 'snowball_id' })
   snowball: SnowballEntity;
+
+  @ManyToOne(
+    () => DecorationPrefixEntity,
+    decorationPrefix => decorationPrefix.decorations
+  )
+  @JoinColumn({ name: 'decoration_id' })
+  decorationPrefix: DecorationPrefixEntity;
 }

--- a/back/src/modules/snowball/snowball.controller.ts
+++ b/back/src/modules/snowball/snowball.controller.ts
@@ -6,7 +6,8 @@ import {
   Param,
   Get,
   HttpCode,
-  UseGuards
+  UseGuards,
+  Req
 } from '@nestjs/common';
 import { SnowballService } from './snowball.service';
 import {
@@ -44,9 +45,13 @@ export class SnowballController {
   })
   @ApiBody({ type: ReqCreateSnowballDto })
   createSnowball(
+    @Req() req: any,
     @Body() createSnowballDto: ReqCreateSnowballDto
   ): Promise<SnowballDto> {
-    const snowball = this.snowballService.createSnowball(createSnowballDto);
+    const snowball = this.snowballService.createSnowball(
+      req.user,
+      createSnowballDto
+    );
     return snowball;
   }
 

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -21,10 +21,11 @@ export class SnowballService {
   ) {}
 
   async createSnowball(
+    userid: number,
     createSnowballDto: ReqCreateSnowballDto
   ): Promise<SnowballDto> {
     const snowball = this.snowballRepository.create({
-      user_id: createSnowballDto.user_id,
+      user_id: userid,
       title: createSnowballDto.title,
       message_private: createSnowballDto.is_message_private ? new Date() : null
     });


### PR DESCRIPTION
## 💡 완료된 기능
- [x] 메시지 오픈 표시 API 생성
    - PUT /message/open/3 이런 식으로 메시지를 오픈했다는 표시해줄 수 있습니다.
- [x] user_id는 JWT토큰에서 가져오기로 변경
- [x] message 테이블에 user_id 칼럼 추가
- [ ] user_id 인덱스 설정

## 📷 완료된 기능 사진
<div align="center">
  <span>메시지 오픈 표시 API<span>
  <img width="949" alt="Screenshot 2023-11-23 at 1 41 50 PM" src="https://github.com/boostcampwm2023/web11-SSOCK/assets/33882299/65b36798-0ac4-464a-8763-0c5db4223a81">

  <span>Delete실패시 HTTPResponse 다양하게<span>
<img width="430" alt="image" src="https://github.com/boostcampwm2023/web11-SSOCK/assets/33882299/6dc3b428-1570-4af1-a252-b475e03fb352">


</div>
