### PR TITLE
[송현우] visitor 조회 로직 완성

### DIFF
--- a/back/src/modules/auth/auth.controller.ts
+++ b/back/src/modules/auth/auth.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Req, Param, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ResInfoDto } from './dto/response/res-info.dto';
 import { AuthService } from './auth.service';
+import { ResVisitInfoDto } from './dto/response/res-visit-info.do';
 
 @ApiTags('Oauth API')
 @Controller('auth')
@@ -38,7 +39,7 @@ export class AuthController {
   })
   async googleLoginCallback(@Req() req): Promise<ResInfoDto> {
     const userInfo = req.user;
-    const result = this.authService.createInfo(userInfo);
+    const result = this.authService.createUserInfo(userInfo);
     return result;
   }
 
@@ -72,7 +73,7 @@ export class AuthController {
   })
   async naverLoginCallBack(@Req() req): Promise<ResInfoDto> {
     const userInfo = req.user;
-    const result = this.authService.createInfo(userInfo);
+    const result = this.authService.createUserInfo(userInfo);
     return result;
   }
 
@@ -106,7 +107,24 @@ export class AuthController {
   })
   async kakaoLoginCallBack(@Req() req): Promise<ResInfoDto> {
     const userInfo = req.user;
-    const result = this.authService.createInfo(userInfo);
+    const result = this.authService.createUserInfo(userInfo);
+    return result;
+  }
+
+  @Get('visit/:user_id')
+  @ApiOperation({
+    summary: '방문자 유저 조회 API',
+    description: '방문자가 접속한 유저의 정보를 반환합니다'
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Internal Server Error',
+    type: ResVisitInfoDto
+  })
+  async createVisitInfo(
+    @Param('user_id') user_id: string
+  ): Promise<ResVisitInfoDto> {
+    const result = this.authService.createVisitInfo(user_id);
     return result;
   }
 }

--- a/back/src/modules/auth/auth.module.ts
+++ b/back/src/modules/auth/auth.module.ts
@@ -9,15 +9,17 @@ import { SnowballService } from '../snowball/snowball.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SnowballEntity } from '../snowball/entity/snowball.entity';
 import { UserEntity } from './entity/user.entity';
-import { SnowballDecorationEntity } from '../snowball/entity/snowball-decoration.entity';
 import { JWTGuard } from './auth.guard';
+import { MessageEntity } from '../message/entity/message.entity';
+import { SnowballDecorationEntity } from '../snowball/entity/snowball-decoration.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      SnowballEntity,
       UserEntity,
-      SnowballDecorationEntity
+      SnowballEntity,
+      SnowballDecorationEntity,
+      MessageEntity
     ]),
     PassportModule
   ],

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
   ): Promise<UserDto> {
     let snowball_count: number,
       message_count: number,
-      snowball_list: { id: number; uuid: string }[],
+      snowball_list: number[],
       main_snowball_id: number | null;
     if (is_existed) {
       const snowballs = await this.SnowballRepository.findAndCount({
@@ -54,10 +54,7 @@ export class AuthService {
       });
       snowball_count = snowballs[1];
       snowball_list = snowballs[0].map(snowball => {
-        return {
-          id: snowball.id,
-          uuid: snowball.snowball_uuid
-        };
+        return snowball.id;
       });
       main_snowball_id = snowballs[0][0].id;
     } else {

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ResInfoDto } from './dto/response/res-info.dto';
 import { UserDto } from './dto/user.dto';
 import { SnowballDto } from '../snowball/dto/snowball.dto';
@@ -8,6 +8,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserEntity } from './entity/user.entity';
 import { SnowballEntity } from '../snowball/entity/snowball.entity';
+import { ResVisitInfoDto } from './dto/response/res-visit-info.do';
+import { MessageEntity } from '../message/entity/message.entity';
+interface SnowballInfo {
+  snowball_count: number;
+  message_count: number;
+  snowball_list: number[];
+  main_snowball_id: number | null;
+}
 @Injectable()
 export class AuthService {
   constructor(
@@ -15,20 +23,22 @@ export class AuthService {
     private readonly UserRepository: Repository<UserEntity>,
     @InjectRepository(SnowballEntity)
     private readonly SnowballRepository: Repository<SnowballEntity>,
+    @InjectRepository(MessageEntity)
+    private readonly MessageRepository: Repository<MessageEntity>,
     private readonly jwtService: JwtService,
     private readonly snowballService: SnowballService
   ) {}
 
-  async createInfo(user: any): Promise<ResInfoDto> {
+  async createUserInfo(user: any): Promise<ResInfoDto> {
     const { user_pk, is_existed } = await this.getUserPk(user);
     const jwt_token = this.generateJwtToken(user_pk);
     const userDto: UserDto = await this.createUserDto(
-      user,
       user_pk,
+      user.name,
+      user.id,
       is_existed
     );
-    const mainSnowballDto: SnowballDto =
-      await this.snowballService.getSnowball(1);
+    const mainSnowballDto = await this.getMainSnowballDto(userDto);
 
     const resInfoDto: ResInfoDto = {
       jwt_token,
@@ -39,34 +49,39 @@ export class AuthService {
     return resInfoDto;
   }
 
+  async createVisitInfo(user_id: string): Promise<ResVisitInfoDto> {
+    const user = await this.UserRepository.findOne({
+      where: { user_id: user_id }
+    });
+    if (!user) throw new NotFoundException('해당 유저를 찾을 수 없습니다.');
+    const userDto: UserDto = await this.createUserDto(
+      user.id,
+      user.username,
+      user.user_id,
+      true
+    );
+    const mainSnowballDto = await this.getMainSnowballDto(userDto);
+
+    const resVisitInfo: ResVisitInfoDto = {
+      user: userDto,
+      main_snowball: mainSnowballDto
+    };
+    return resVisitInfo;
+  }
+
   async createUserDto(
-    user: any,
     user_pk: number,
+    username: string,
+    user_id: string,
     is_existed: boolean
   ): Promise<UserDto> {
-    let snowball_count: number,
-      message_count: number,
-      snowball_list: number[],
-      main_snowball_id: number | null;
-    if (is_existed) {
-      const snowballs = await this.SnowballRepository.findAndCount({
-        where: { user_id: user_pk }
-      });
-      snowball_count = snowballs[1];
-      snowball_list = snowballs[0].map(snowball => {
-        return snowball.id;
-      });
-      main_snowball_id = snowballs[0][0].id;
-    } else {
-      snowball_count = 0;
-      message_count = 0;
-      snowball_list = [];
-      main_snowball_id = null;
-    }
+    const { snowball_count, message_count, snowball_list, main_snowball_id } =
+      await this.getSnowballInfo(user_pk, is_existed);
+
     const userDto: UserDto = {
       id: user_pk,
-      name: user.name,
-      auth_id: user.id,
+      name: username,
+      auth_id: user_id,
       snowball_count: snowball_count,
       main_snowball_id: main_snowball_id,
       snowball_list: snowball_list,
@@ -95,6 +110,43 @@ export class AuthService {
       const pk = saveduser.identifiers.pop().id;
       return { user_pk: pk, is_existed: false };
     }
+  }
+
+  async getMainSnowballDto(userDto: UserDto): Promise<SnowballDto | null> {
+    if (!userDto.main_snowball_id) {
+      return null;
+    } else {
+      return await this.snowballService.getSnowball(userDto.main_snowball_id);
+    }
+  }
+
+  async getSnowballInfo(
+    user_pk: number,
+    is_existed: boolean
+  ): Promise<SnowballInfo> {
+    if (is_existed) {
+      const snowballs = await this.SnowballRepository.findAndCount({
+        where: { user_id: user_pk }
+      });
+      const snowball_list = snowballs[0].map(snowball => snowball.id);
+      return {
+        snowball_count: snowballs[1],
+        message_count: await this.getMessageCount(user_pk),
+        snowball_list,
+        main_snowball_id: snowballs[0][0].id
+      };
+    } else {
+      return {
+        snowball_count: 0,
+        message_count: 0,
+        snowball_list: [],
+        main_snowball_id: null
+      };
+    }
+  }
+
+  async getMessageCount(user_pk: number): Promise<number> {
+    return this.MessageRepository.count({ where: { user: { id: user_pk } } });
   }
 
   generateJwtToken(user_pk: any): string {

--- a/back/src/modules/auth/dto/response/res-visit-info.do.ts
+++ b/back/src/modules/auth/dto/response/res-visit-info.do.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty } from '@nestjs/class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserDto } from '../user.dto';
+import { SnowballDto } from '../../../snowball/dto/snowball.dto';
+
+export class ResVisitInfoDto {
+  @IsNotEmpty()
+  @ApiProperty({
+    type: UserDto,
+    description: '사용자 정보 '
+  })
+  readonly user: UserDto;
+
+  @IsNotEmpty()
+  @ApiProperty({
+    type: SnowballDto,
+    description: '메인 스노우볼 정보'
+  })
+  readonly main_snowball: SnowballDto | null;
+}

--- a/back/src/modules/auth/dto/user.dto.ts
+++ b/back/src/modules/auth/dto/user.dto.ts
@@ -28,17 +28,10 @@ export class UserDto {
 
   @IsNotEmpty()
   @ApiProperty({
-    type: 'array',
-    items: {
-      type: 'object',
-      properties: {
-        id: { type: 'number' },
-        uuid: { type: 'string' }
-      }
-    },
-    description: '스노우볼 key-value 리스트'
+    type: [Number],
+    description: '스노우볼 id 리스트'
   })
-  readonly snowball_list: { id: number; uuid: string }[];
+  readonly snowball_list: number[];
 
   @IsNumber()
   @IsNotEmpty()

--- a/back/src/modules/auth/dto/user.dto.ts
+++ b/back/src/modules/auth/dto/user.dto.ts
@@ -24,7 +24,7 @@ export class UserDto {
 
   @IsNumber()
   @ApiProperty({ type: Number, description: '메인 스노우볼 id' })
-  readonly main_snowball_id: number;
+  readonly main_snowball_id: number | null;
 
   @IsNotEmpty()
   @ApiProperty({

--- a/back/src/modules/message/entity/letter.entity.ts
+++ b/back/src/modules/message/entity/letter.entity.ts
@@ -5,6 +5,6 @@ export class LetterEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ type: 'boolean', default: true })
   active: boolean;
 }

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -37,8 +37,9 @@ export class MessageService {
       content: createMessageDto.content,
       decoration_id: createMessageDto.decoration_id,
       decoration_color: createMessageDto.decoration_color,
-      letter_id: createMessageDto.letter_id
-      // opened와 created는 자동으로 설정
+      letter_id: createMessageDto.letter_id,
+      opened: null
+      // is_deleted랑 created는 자동으로 설정
     });
     const savedMessage = await this.messageRepository.save(messageEntity);
 
@@ -88,9 +89,9 @@ export class MessageService {
     if (!user) {
       throw new NotFoundException(`User with id ${user_id} not found`);
     }
-    const messages: MessageEntity[] = user.snowballs.flatMap(
-      snowball => snowball.messages
-    );
+    const messages: MessageEntity[] = user.snowballs
+      .flatMap(snowball => snowball.messages)
+      .filter(message => !message.is_deleted);
     const messagesDto: MessageDto[] = messages.map(message => {
       const {
         id,

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -118,29 +118,26 @@ export class MessageService {
   }
 
   async openMessage(message_id: number): Promise<MessageDto> {
-    try {
-      const message = await this.messageRepository.findOne({
-        where: { id: message_id }
-      });
-      if (!message) {
-        throw new NotFoundException(
-          `${message_id} 메시지를 찾을 수 없었습니다.`
-        );
-      }
-      if (message.opened !== null) {
-        throw new ConflictException(
-          `${message_id} 메시지는 이미 열려있습니다.`
-        );
-      }
-      const date = new Date();
-      await this.messageRepository.update(message_id, { opened: date });
-      return {
-        ...message,
-        opened: date
-      };
-    } catch (err) {
-      throw new InternalServerErrorException('서버측 오류');
+    const message = await this.messageRepository.findOne({
+      where: { id: message_id }
+    });
+    console.log(message);
+    if (!message) {
+      throw new NotFoundException(
+        `${message_id}번 메시지를 찾을 수 없었습니다.`
+      );
     }
+    if (message.opened !== null) {
+      throw new ConflictException(
+        `${message_id}번 메시지는 이미 열려있습니다.`
+      );
+    }
+    const date = new Date();
+    await this.messageRepository.update(message_id, { opened: date });
+    return {
+      ...message,
+      opened: date
+    };
   }
 
   async getUserId(snowball_id: number): Promise<number> {

--- a/back/src/modules/snowball/dto/snowball.dto.ts
+++ b/back/src/modules/snowball/dto/snowball.dto.ts
@@ -1,6 +1,5 @@
 import {
   IsString,
-  IsUUID,
   IsBoolean,
   IsNumber,
   IsNotEmpty,
@@ -21,11 +20,6 @@ export class SnowballDto {
   @IsNumber()
   @ApiProperty({ type: Number, description: '스노우볼 id' })
   readonly id: number;
-
-  @IsUUID('4')
-  @IsNotEmpty()
-  @ApiProperty({ format: 'uuid', description: '스노우볼 UUID' })
-  readonly uuid: string;
 
   @IsBoolean()
   @IsNotEmpty()

--- a/back/src/modules/snowball/entity/decoration-prefix.entity.ts
+++ b/back/src/modules/snowball/entity/decoration-prefix.entity.ts
@@ -4,6 +4,6 @@ export class DecorationPrefixEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ type: 'boolean', default: true })
   active: boolean;
 }

--- a/back/src/modules/snowball/entity/snowball.entity.ts
+++ b/back/src/modules/snowball/entity/snowball.entity.ts
@@ -1,32 +1,23 @@
-import { IsUUID } from '@nestjs/class-validator';
-import { v4 as uuidv4 } from 'uuid';
 import {
   Entity,
   Column,
-  Index,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   ManyToOne,
   OneToMany,
-  JoinColumn,
-  BeforeInsert
+  JoinColumn
 } from 'typeorm';
 import { UserEntity } from '../../auth/entity/user.entity';
 import { SnowballDecorationEntity } from './snowball-decoration.entity';
 import { MessageEntity } from '../../message/entity/message.entity';
 
 @Entity({ name: 'snowball' })
-@Index(['snowball_uuid'], { unique: true })
 export class SnowballEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column()
   user_id: number;
-
-  @IsUUID('4')
-  @Column({ length: 36 })
-  snowball_uuid: string;
 
   @Column({ length: 16 })
   title: string;
@@ -46,9 +37,4 @@ export class SnowballEntity {
 
   @OneToMany(() => SnowballDecorationEntity, decoration => decoration.snowball)
   decorations: SnowballDecorationEntity[];
-
-  @BeforeInsert()
-  generateSnowballUUID() {
-    this.snowball_uuid = uuidv4();
-  }
 }

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -38,7 +38,6 @@ export class SnowballService {
     }
     const combinedSnowballDto: SnowballDto = {
       id: savedSnowball.id,
-      uuid: savedSnowball.snowball_uuid,
       title: savedSnowball.title,
       is_message_private: savedSnowball.message_private === null ? false : true,
       deco_list: decoList,
@@ -131,7 +130,6 @@ export class SnowballService {
 
     const resSnowball: SnowballDto = {
       id: snowball.id,
-      uuid: snowball.snowball_uuid,
       title: snowball.title,
       is_message_private: snowball.message_private ? true : false,
       deco_list: snowball.decorations,


### PR DESCRIPTION
## 💡 완료된 기능
- [x] snowball uuid 제거
- [x] visitor 조회 api 완성
- [x] open처리 api 오류 수정 

로직 대강 설명
https://github.com/boostcampwm2023/web11-SSOCK/pull/129 이것두 참고
1. payload에 user_id를 담으면 로직상 순환참조가 발생할 수 밖에 없었음 !! <- 이거 해결하느라 한참걸림
2. payload에 user_id가 아닌 user_pk(id)가 담기도록 수정해서 해결 -> getUserPk함수 만들었음
3. payload에 담은 user_pk로 다른 로직들도 SELECT할 수 있어서 쿼리비용 낮아짐
4. 나머지는 함수 분리 최대한 해서 서비스 로직 짜봤음 !!