### PR TITLE
[송현우] clova api 연동

### DIFF
--- a/back/src/common/interface/request.interface.ts
+++ b/back/src/common/interface/request.interface.ts
@@ -4,7 +4,7 @@ export interface JWTRequest extends Request {
   user: {
     id: number;
     name: string;
-    user_id: string;
+    auth_id: string;
   };
 
   hasToken?: boolean;

--- a/back/src/common/strategy/google-auth.strategy.ts
+++ b/back/src/common/strategy/google-auth.strategy.ts
@@ -26,7 +26,7 @@ export class GoogleAuthStrategy extends PassportStrategy(Strategy, 'google') {
   ) {
     try {
       const user = {
-        user_id: profile.id,
+        auth_id: profile.id,
         name: profile.displayName,
         provider: profile.provider,
         accessToken,

--- a/back/src/common/strategy/kakao-auth.strategy.ts
+++ b/back/src/common/strategy/kakao-auth.strategy.ts
@@ -23,7 +23,7 @@ export class KakaoAuthStrategy extends PassportStrategy(Strategy, 'kakao') {
     try {
       console.log(profile);
       const user = {
-        user_id: profile.id,
+        auth_id: profile.id,
         name: profile.displayName,
         provider: profile.provider,
         accessToken,

--- a/back/src/common/strategy/naver-auth.strategy.ts
+++ b/back/src/common/strategy/naver-auth.strategy.ts
@@ -23,7 +23,7 @@ export class NaverAuthStrategy extends PassportStrategy(Strategy, 'naver') {
     try {
       console.log(profile);
       const user = {
-        user_id: profile.id,
+        auth_id: profile.id,
         name: profile.name,
         provider: profile.provider,
         accessToken,

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -7,7 +7,7 @@ import { Repository } from 'typeorm';
 export interface payload {
   id: number;
   name: string;
-  user_id: string;
+  auth_id: string;
 }
 @Injectable()
 export class AuthService {
@@ -19,13 +19,13 @@ export class AuthService {
 
   async getUserInfo(user: any): Promise<payload> {
     const exisitingUser = await this.UserRepository.findOne({
-      where: { user_id: user.user_id }
+      where: { auth_id: user.auth_id }
     });
     if (exisitingUser) {
       return {
         id: exisitingUser.id,
         name: exisitingUser.username,
-        user_id: exisitingUser.user_id
+        auth_id: exisitingUser.auth_id
       };
     } else {
       return await this.signUp(user);
@@ -34,7 +34,7 @@ export class AuthService {
 
   async signUp(user: any): Promise<payload> {
     const newUser: UserEntity = this.UserRepository.create({
-      user_id: user.user_id,
+      auth_id: user.auth_id,
       username: user.name,
       nickname: null,
       provider: user.provider,
@@ -42,7 +42,7 @@ export class AuthService {
     });
     const saveduser = await this.UserRepository.insert(newUser);
     const id = saveduser.identifiers.pop().id;
-    return { id: id, name: user.name, user_id: user.user_id };
+    return { id: id, name: user.name, auth_id: user.auth_id };
   }
 
   generateJwtToken(payload: payload): {

--- a/back/src/modules/message/dto/clova-content.dto.ts
+++ b/back/src/modules/message/dto/clova-content.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from '@nestjs/class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClovaContentDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ type: String, description: 'Clova 전송 컨텐츠' })
+  readonly content: string;
+}

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -31,10 +31,15 @@ import { JWTGuard } from 'src/common/guards/jwt.guard';
 import { UpdateMessageDecorationDto } from './dto/update-message-decoration.dto';
 import { UpdateMessageLocationDto } from './dto/update-message-location.dto';
 import { JWTRequest } from 'src/common/interface/request.interface';
+import { ClovaService } from './summary.service';
+import { ClovaContentDto } from './dto/clova-content.dto';
 @ApiTags('Message API')
 @Controller('message')
 export class MessageController {
-  constructor(private readonly messageService: MessageService) {}
+  constructor(
+    private readonly messageService: MessageService,
+    private readonly clovaService: ClovaService
+  ) {}
 
   @Post('/:user_id/:snowball_id')
   @HttpCode(201)
@@ -203,5 +208,16 @@ export class MessageController {
       message_id,
       updateMessageLocationDto
     );
+  }
+
+  // Test
+  @Post('/summarize')
+  async summarize(@Body() clovaDto: ClovaContentDto): Promise<string> {
+    return this.clovaService.summarize(clovaDto);
+  }
+
+  @Post('/analyze')
+  async analyze(@Body() clovaDto: ClovaContentDto): Promise<string> {
+    return this.clovaService.analyze(clovaDto);
   }
 }

--- a/back/src/modules/message/message.module.ts
+++ b/back/src/modules/message/message.module.ts
@@ -4,10 +4,11 @@ import { MessageController } from './message.controller';
 import { MessageService } from './message.service';
 import { MessageEntity } from './entity/message.entity';
 import { JWTGuard } from '../../common/guards/jwt.guard';
+import { ClovaService } from './summary.service';
 @Module({
   imports: [TypeOrmModule.forFeature([MessageEntity])],
   controllers: [MessageController],
-  providers: [MessageService, JWTGuard],
+  providers: [MessageService, ClovaService, JWTGuard],
   exports: [MessageService, TypeOrmModule]
 })
 export class MessageModule {}

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -168,9 +168,9 @@ export class MessageService {
     return updateMessageLocationDto;
   }
 
-  async getMessageCount(user_pk: number): Promise<number> {
+  async getMessageCount(user_id: number): Promise<number> {
     return this.messageRepository.count({
-      where: { user_id: user_pk, is_deleted: false }
+      where: { user_id: user_id, is_deleted: false }
     });
   }
 

--- a/back/src/modules/message/summary.service.ts
+++ b/back/src/modules/message/summary.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import axios from 'axios';
+import { ClovaContentDto } from './dto/clova-content.dto';
+
+@Injectable()
+export class ClovaService {
+  private readonly clovaSummaryApiUrl =
+    'https://naveropenapi.apigw.ntruss.com/text-summary/v1/summarize';
+  private readonly clovaSentimentApiUrl =
+    'https://naveropenapi.apigw.ntruss.com/sentiment-analysis/v1/analyze';
+  private readonly clovaSummaryClientID = `${process.env.CLOVA_SUMMARY_CLIENT_ID}`;
+  private readonly clovaSummarySecret = `${process.env.CLOVA_SUMMARY_SECRET}`;
+  private readonly clovaSentimentClientID = `${process.env.CLOVA_SENTIMENT_CLIENT_ID}`;
+  private readonly clovaSentimentSecret = `${process.env.CLOVA_SENTIMENT_SECRET}`;
+
+  async summarize(clovaDto: ClovaContentDto): Promise<string> {
+    const content = clovaDto.content;
+    const data = {
+      document: {
+        content: content
+      },
+      option: {
+        language: 'ko',
+        model: 'general',
+        tone: '0', // 현재 말투 유지
+        summaryCount: '1'
+      }
+    };
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-NCP-APIGW-API-KEY-ID': this.clovaSummaryClientID,
+      'X-NCP-APIGW-API-KEY': this.clovaSummarySecret
+    };
+    try {
+      const response = await axios.post(this.clovaSummaryApiUrl, data, {
+        headers
+      });
+      return response.data.summary;
+    } catch (error) {
+      console.error('Error calling Clova Summary API:', error.message);
+      throw new InternalServerErrorException('Failed to summarize text');
+    }
+  }
+
+  async analyze(clovaDto: ClovaContentDto): Promise<string> {
+    const content = clovaDto.content;
+    const data = {
+      content: content
+    };
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-NCP-APIGW-API-KEY-ID': this.clovaSentimentClientID,
+      'X-NCP-APIGW-API-KEY': this.clovaSentimentSecret
+    };
+    try {
+      const response = await axios.post(this.clovaSentimentApiUrl, data, {
+        headers
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error calling Clova Sentiment API:', error.message);
+      throw new InternalServerErrorException('Failed to analyze text');
+    }
+  }
+}

--- a/back/src/modules/snowball/snowball.controller.ts
+++ b/back/src/modules/snowball/snowball.controller.ts
@@ -8,7 +8,8 @@ import {
   HttpCode,
   UseGuards,
   Req,
-  UseInterceptors
+  UseInterceptors,
+  NotFoundException
 } from '@nestjs/common';
 import { SnowballService } from './snowball.service';
 import {
@@ -104,6 +105,7 @@ export class SnowballController {
       snowball_id,
       req.hasToken
     );
+    if (!snowball) throw new NotFoundException('스노우볼을 찾을 수 없습니다.');
     return snowball;
   }
 

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -75,7 +75,7 @@ export class SnowballService {
   async updateSnowball(
     updateSnowballDto: ReqUpdateSnowballDto,
     snowball_id: number,
-    user_pk: number
+    user_id: number
   ): Promise<ResUpdateSnowballDto> {
     const { title, is_message_private } = updateSnowballDto;
 
@@ -89,7 +89,7 @@ export class SnowballService {
         message_private: is_message_private ? new Date() : null
       })
       .where('id = :id', { id: snowball_id })
-      .andWhere('user_id = :user_id', { user_id: user_pk })
+      .andWhere('user_id = :user_id', { user_id: user_id })
       .execute();
     if (!updateResult.affected) {
       throw new NotFoundException('스노우볼 업데이트 권한이 없습니다');
@@ -143,7 +143,7 @@ export class SnowballService {
   async updateMainDecoration(
     updateMainDecoDto: UpdateMainDecoDto,
     snowball_id: number,
-    user_pk: number
+    user_id: number
   ): Promise<UpdateMainDecoDto> {
     await this.doesSnowballExist(snowball_id);
     await this.doesDecorationExist(updateMainDecoDto.main_decoration_id);
@@ -156,7 +156,7 @@ export class SnowballService {
         ...updateMainDecoDto
       })
       .where('id = :id', { id: snowball_id })
-      .andWhere('user_id = :user_id', { user_id: user_pk })
+      .andWhere('user_id = :user_id', { user_id: user_id })
       .execute();
 
     if (!updateResult.affected) {
@@ -177,9 +177,9 @@ export class SnowballService {
     }
   }
 
-  async getSnowballInfo(user_pk: number): Promise<SnowballInfo> {
+  async getSnowballInfo(user_id: number): Promise<SnowballInfo> {
     const snowballs = await this.snowballRepository.findAndCount({
-      where: { user_id: user_pk }
+      where: { user_id: user_id }
     });
 
     const [items = [], count = 0] = snowballs;
@@ -187,7 +187,7 @@ export class SnowballService {
       const snowball_list = items.map(snowball => snowball.id);
       return {
         snowball_count: count,
-        message_count: await this.messageService.getMessageCount(user_pk),
+        message_count: await this.messageService.getMessageCount(user_id),
         snowball_list,
         main_snowball_id: items[0].id
       };

--- a/back/src/modules/user/dto/user.dto.ts
+++ b/back/src/modules/user/dto/user.dto.ts
@@ -30,7 +30,7 @@ export class UserDto {
   @Length(1, 45)
   @IsNotEmpty()
   @ApiProperty({ type: String, description: 'Oauth에서 주는 값' })
-  readonly user_id: string;
+  readonly auth_id: string;
 
   @IsNumber()
   @IsPositive()

--- a/back/src/modules/user/entity/user.entity.ts
+++ b/back/src/modules/user/entity/user.entity.ts
@@ -10,13 +10,13 @@ import { SnowballEntity } from '../../snowball/entity/snowball.entity';
 import { MessageEntity } from 'src/modules/message/entity/message.entity';
 
 @Entity({ name: 'user' })
-@Index(['user_id'], { unique: true })
+@Index(['auth_id'], { unique: true })
 export class UserEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column({ length: 45 })
-  user_id: string;
+  auth_id: string;
 
   @Column({ length: 16 })
   username: string;

--- a/back/src/modules/user/user.controller.ts
+++ b/back/src/modules/user/user.controller.ts
@@ -41,7 +41,7 @@ export class UserController {
     return result;
   }
 
-  @Get('/:user_id')
+  @Get('/:auth_id')
   @ApiOperation({
     summary: '방문자 유저 조회 API',
     description: '방문자가 접속한 유저의 정보를 반환합니다'
@@ -52,9 +52,9 @@ export class UserController {
     type: ResInfoDto
   })
   async createVisitInfo(
-    @Param('user_id') user_id: string
+    @Param('auth_id') auth_id: string
   ): Promise<ResInfoDto> {
-    const userData = await this.userService.getUserData(user_id);
+    const userData = await this.userService.getUserData(auth_id);
     const result = this.userService.createUserInfo(userData, false);
     return result;
   }

--- a/back/src/modules/user/user.service.ts
+++ b/back/src/modules/user/user.service.ts
@@ -10,7 +10,7 @@ import { NicknameDto } from './dto/nickname.dto';
 interface userData {
   id: number;
   name: string;
-  user_id: string;
+  auth_id: string;
 }
 
 @Injectable()
@@ -21,15 +21,15 @@ export class UserService {
     private readonly userRepository: Repository<UserEntity>
   ) {}
 
-  async getUserData(user_id: string): Promise<userData> {
+  async getUserData(auth_id: string): Promise<userData> {
     const exisitingUser = await this.userRepository.findOne({
-      where: { user_id: user_id }
+      where: { auth_id: auth_id }
     });
     if (exisitingUser) {
       return {
         id: exisitingUser.id,
         name: exisitingUser.username,
-        user_id: exisitingUser.user_id
+        auth_id: exisitingUser.auth_id
       };
     } else {
       throw new NotFoundException('해당 유저를 찾을 수 없습니다.');
@@ -51,7 +51,7 @@ export class UserService {
     const userDto: UserDto = await this.createUserDto(
       user.id,
       user.name,
-      user.user_id
+      user.auth_id
     );
     const mainSnowballDto = await this.snowballService.getMainSnowballDto(
       userDto,
@@ -69,7 +69,7 @@ export class UserService {
   async createUserDto(
     id: number,
     username: string,
-    user_id: string
+    auth_id: string
   ): Promise<UserDto> {
     const { snowball_count, message_count, snowball_list, main_snowball_id } =
       await this.snowballService.getSnowballInfo(id);
@@ -79,7 +79,7 @@ export class UserService {
       id: id,
       username: username,
       nickname: nickname,
-      user_id: user_id,
+      auth_id: auth_id,
       snowball_count: snowball_count,
       main_snowball_id: main_snowball_id,
       snowball_list: snowball_list,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@nestjs/class-validator": "^0.13.4",
+        "axios": "^1.6.2",
         "express-basic-auth": "^1.2.1"
       }
     },
@@ -16,6 +17,21 @@
       "dependencies": {
         "libphonenumber-js": "^1.9.43",
         "validator": "^13.7.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/basic-auth": {
@@ -29,6 +45,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/express-basic-auth": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
@@ -37,10 +72,66 @@
         "basic-auth": "^2.0.1"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/libphonenumber-js": {
       "version": "1.10.49",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.49.tgz",
       "integrity": "sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ=="
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@nestjs/class-validator": "^0.13.4",
+    "axios": "^1.6.2",
     "express-basic-auth": "^1.2.1"
   }
 }


### PR DESCRIPTION
## 💡 완료된 기능
- [x] clova api 다들 써볼 수 있도록 swagger api 추가
- [x] id, user_id -> id, auth_id, user_id로 변경
- [x]  getSnowball 함수를 다른 서비스 로직에서도 사용하고 있어, 스노우볼이 없을 시 return null;을 하고있었음. 이때 스노우볼 조회시 없는 스노우볼을 조회해도 null이 리턴됨! -> 컨트롤러에서 throw를 던지도록 함

기존에는 user_id가 number인지 string인지 서비스마다 혼동되어 사용됐었음

id : 해당 테이블의 pk (number)
auth_id : 유저 테이블의 인증 id (string)
user_id: 유저 테이블의 pk (number)

이렇게 변경함!
이제 string타입은 무조건 auth_id로 하여 혼동이 없게 변경했음