### PR TITLE
[오승엽] mesh utils 분리

### DIFF
--- a/front/src/components/Msg/Msg.tsx
+++ b/front/src/components/Msg/Msg.tsx
@@ -19,6 +19,7 @@ const StyledLetterBox = styled.div<MsgColor>`
   display: flex;
   align-self: center;
   font: ${props => props.theme.font['--normal-introduce-font']};
+  text-shadow: -1px 0px black, 0px 1px black, 1px 0px black, 0px -1px black;
   flex-direction: column;
   border-radius: 1rem;
   padding: 1.5rem;
@@ -98,6 +99,7 @@ const StyledFromInput = styled.input`
   border: none;
   background-color: transparent;
   color: ${props => props.theme.colors['--nick-name']};
+  text-shadow: -1px 0px black, 0px 1px black, 1px 0px black, 0px -1px black;
   font-size: 1rem;
   font-weight: 700;
   pointer-events: stroke;

--- a/front/src/components/SnowGlobeCanvas/models/Bottom.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Bottom.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
 import { BOTTOM } from '../../../constants/deco';
+import * as MeshUtils from '../../../utils/meshUtils';
 
 interface BottomProps {
   scale: number;
@@ -20,30 +21,18 @@ const Bottom: React.FC<BottomProps> = ({
 }) => {
   const bottom = useGLTF(BOTTOM[bottomID].fileName).scene.clone();
   const nameTag = bottom.getObjectByName('nameTag') as THREE.Mesh;
-  if (nameTag) {
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d');
-    const material = nameTag.material as THREE.MeshStandardMaterial;
-    canvas.width = 1024;
-    canvas.height = 1024;
-
-    if (context) {
-      context.fillStyle = '#ffffff';
-      context.fillRect(0, 0, 1024, 1024);
-      context.font = 'Bold 6.25rem KingSejongInstitute';
-      context.fillStyle = '#131313';
-      context.textBaseline = 'middle';
-
-      const textWidth = context.measureText(title).width;
-      if (textWidth > 1000) {
-        context.font = 'Bold 3.125rem KingSejongInstitute';
-      }
-      context.fillText(title, canvas.width / 2 - textWidth / 2, 1024 / 8, 1024);
-    }
-
-    const nameTexture = new THREE.CanvasTexture(canvas);
-    material.map = nameTexture;
-    material.bumpMap = nameTexture;
+  if (nameTag && nameTag.material instanceof THREE.MeshStandardMaterial) {
+    const newTexture = MeshUtils.makeCanvasTexture({
+      string: title,
+      width: 1024,
+      height: 1024,
+      positionY: 1024 / 8,
+      font: 'Bold 6.25rem KingSejongInstitute',
+      fontColor: 'black',
+      backgGroundColor: 'white'
+    });
+    nameTag.material.map = newTexture;
+    nameTag.material.bumpMap = newTexture;
   }
 
   const mainColor = bottom.getObjectByName('mainColor') as THREE.Mesh;

--- a/front/src/components/SnowGlobeCanvas/models/Deco.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Deco.tsx
@@ -1,6 +1,7 @@
 import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
 import { DECO, MSG_COLOR } from '../../../constants/deco';
+import * as MeshUtils from '../../../utils/meshUtils';
 
 interface DecoProps {
   id: number;
@@ -34,15 +35,9 @@ const Deco = ({
       child.userData.sender = sender;
       child.userData.color = color;
       child.userData.letterColor = MSG_COLOR[letterID].color;
-
       child.castShadow = true;
-      if (child.name === 'Sub') {
-        return;
-      }
       if (child.name === 'Main') {
-        const newMaterial = child.material.clone();
-        newMaterial.color = new THREE.Color(color);
-        child.material = newMaterial;
+        child.material = MeshUtils.makeColorChangedMaterial(child, color);
       }
     }
   });

--- a/front/src/components/SnowGlobeCanvas/models/MainDeco.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/MainDeco.tsx
@@ -37,7 +37,7 @@ const MainDeco = ({ id, scale, position, color }: MyModelProps) => {
   const deco = useGLTF(MAIN[id].fileName).scene.clone();
   const speedRef = useRef(new THREE.Vector3(0, -0.01, 0));
 
-  //run build error 해결용 consol
+  //run build error 해결용 console model업데이트 후 색상 적용해야됨
   console.log(color);
   deco.name = MAIN[id].name;
   deco.scale.set(scale, scale, scale);

--- a/front/src/mockdata.json
+++ b/front/src/mockdata.json
@@ -1,22 +1,51 @@
 {
   "snowball_data": {
     "id": 1,
-    "title": "title",
+    "title": "스노우볼 속 내마음❤️",
     "main_decoration_id": 1,
-    "main_decoration_color": "#FFFFFF",
-    "bottom_decoration_id": 1,
-    "bottom_decoration_color": "#FFFFFF",
-    "is_message_private": true,
-    "message_list": []
+    "main_decoration_color": "#ff0000",
+    "bottom_decoration_id": 2,
+    "bottom_decoration_color": "#ff0000",
+    "is_message_private": false,
+    "message_list": [
+      {
+        "content": "안녕 나는 민수야\n 올 한해도 수고 많았어^^",
+        "created": "0",
+        "decoration_color": "#ff0000",
+        "decoration_id": 1,
+        "id": 1,
+        "is_deleted": false,
+        "letter_id": 3,
+        "location": 1,
+        "opened": null,
+        "sender": "박민수",
+        "snowball_id": 1,
+        "user_id": 1
+      },
+      {
+        "content": "메리크리스마스~\n 내년에도 사이좋게 지내자!!.",
+        "created": "0",
+        "decoration_color": "#00ff00",
+        "decoration_id": 2,
+        "id": 2,
+        "is_deleted": false,
+        "letter_id": 5,
+        "location": 2,
+        "opened": null,
+        "sender": "김찬우",
+        "snowball_id": 1,
+        "user_id": 1
+      }
+    ]
   },
   "user_data": {
     "id": 1,
-    "username": "default",
-    "nickname": "default",
+    "username": "김부캠",
+    "nickname": "김부캠",
     "user_id": "00000",
     "snowball_count": 1,
     "main_snowball_id": 1,
-    "snowball_list": [],
-    "message_count": 0
+    "snowball_list": [1],
+    "message_count": 5
   }
 }

--- a/front/src/pages/Intro/Intro.tsx
+++ b/front/src/pages/Intro/Intro.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { SnowGlobeCanvas, UIContainer } from '../../../src/components';
 import IntroButtonBox from './IntroButtonBox';
+import { MessageProvider } from '../Visit/MessageProvider';
 
 const TitleDiv = styled.div`
   display: flex;
@@ -16,13 +17,15 @@ const TitleDiv = styled.div`
 const Intro = () => {
   return (
     <>
-      <SnowGlobeCanvas />
-      <UIContainer>
-        <TitleDiv>
-          <span>스노우볼 속 내마음</span>
-        </TitleDiv>
-        <IntroButtonBox />
-      </UIContainer>
+      <MessageProvider>
+        <SnowGlobeCanvas />
+        <UIContainer>
+          <TitleDiv>
+            <span>스노우볼 속 내마음</span>
+          </TitleDiv>
+          <IntroButtonBox />
+        </UIContainer>
+      </MessageProvider>
     </>
   );
 };

--- a/front/src/pages/Intro/Intro.tsx
+++ b/front/src/pages/Intro/Intro.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { SnowGlobeCanvas, UIContainer } from '../../../src/components';
 import IntroButtonBox from './IntroButtonBox';
 import { MessageProvider } from '../Visit/MessageProvider';
+import MsgBox from './MsgBox';
 
 const TitleDiv = styled.div`
   display: flex;
@@ -23,6 +24,7 @@ const Intro = () => {
           <TitleDiv>
             <span>스노우볼 속 내마음</span>
           </TitleDiv>
+          <MsgBox />
           <IntroButtonBox />
         </UIContainer>
       </MessageProvider>

--- a/front/src/pages/Intro/MsgBox.tsx
+++ b/front/src/pages/Intro/MsgBox.tsx
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+import { Msg } from '../../components';
+import { MessageContext } from '../Visit/MessageProvider';
+import { SnowBallContext } from '../Visit/SnowBallProvider';
+
+const MsgBox = () => {
+  const { message, sender, color } = useContext(MessageContext); // message가 '' 비어있지 않을때
+  const { userData } = useContext(SnowBallContext);
+  return (
+    <>
+      {message !== '' ? (
+        <Msg
+          color={color}
+          isInput={false}
+          content={message}
+          sender={sender}
+          to={userData.nickname}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default MsgBox;

--- a/front/src/pages/Visit/Deco/DecoCanvas/DecoModel.tsx
+++ b/front/src/pages/Visit/Deco/DecoCanvas/DecoModel.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { DECO } from '../../../../constants/deco';
 import { DecoContext } from '../DecoProvider';
 import { useContext } from 'react';
+import { makeColorChangedMaterial } from '../../../../utils/meshUtils';
 
 const DecoModel = () => {
   const { decoID, color } = useContext(DecoContext);
@@ -16,9 +17,7 @@ const DecoModel = () => {
         return;
       }
       if (child.name === 'Main') {
-        const newMaterial = child.material.clone();
-        newMaterial.color = new THREE.Color(color);
-        child.material = newMaterial;
+        child.material = makeColorChangedMaterial(child, color);
       }
     }
   });

--- a/front/src/utils/meshUtils.tsx
+++ b/front/src/utils/meshUtils.tsx
@@ -1,4 +1,3 @@
-import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
 
 const makeColorChangedMaterial = (mesh: THREE.Mesh, color: string) => {

--- a/front/src/utils/meshUtils.tsx
+++ b/front/src/utils/meshUtils.tsx
@@ -1,0 +1,59 @@
+import { useGLTF } from '@react-three/drei';
+import * as THREE from 'three';
+
+const makeColorChangedMaterial = (mesh: THREE.Mesh, color: string) => {
+  const newMaterial = (
+    mesh.material as THREE.Material
+  ).clone() as THREE.Material;
+
+  if (
+    newMaterial instanceof THREE.MeshBasicMaterial ||
+    newMaterial instanceof THREE.MeshStandardMaterial
+  ) {
+    newMaterial.color.set(color);
+  }
+
+  return newMaterial;
+};
+
+interface canvasMaterialProps {
+  string: string;
+  width: number;
+  height: number;
+  positionY: number;
+  font: string;
+  fontColor: string;
+  backgGroundColor: string;
+}
+
+const makeCanvasTexture = (props: canvasMaterialProps) => {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    throw 'context is not exist!!!';
+  }
+
+  [canvas.width, canvas.height] = [props.width, props.height];
+
+  context.fillStyle = props.backgGroundColor;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  context.fillStyle = props.fontColor;
+  context.font = props.font;
+  context.textBaseline = 'middle';
+
+  const textWidth = context.measureText(props.string).width;
+  context.fillText(
+    props.string,
+    canvas.width / 2 - textWidth / 2,
+    props.positionY,
+    canvas.width
+  );
+
+  const nameTexture = new THREE.CanvasTexture(canvas);
+
+  return nameTexture;
+};
+
+export { makeColorChangedMaterial, makeCanvasTexture };


### PR DESCRIPTION
## 💡 완료된 기능
- [x] mesh utils 분리
  - mesh 색상 변경함수
  - canvasTexture 생성함수 ( title )
- [x] mockData (예시화면 데이터) 변경 (메시지 추가해야댐)
- [x] Intro페이지에서 msg확인가능   
- [x] msg안보여서 테두리 추가했씀 (별로면 뺄게요...)

## 📷 완료된 기능 사진
<div align="center">
  <img width=400 src="https://github.com/boostcampwm2023/web11-SSOCK/assets/62386148/dd8808e0-6db5-4835-abee-6bd6bbf60167">
</div>
