### PR TITLE
[송현우] DML에 트랜잭션 적용

### DIFF
--- a/back/src/common/interceptors/transaction.interceptor.ts
+++ b/back/src/common/interceptors/transaction.interceptor.ts
@@ -1,0 +1,40 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor
+} from '@nestjs/common';
+import { Observable, catchError, map } from 'rxjs';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class TransactionInterceptor implements NestInterceptor {
+  constructor(private readonly dataSource: DataSource) {}
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler
+  ): Promise<Observable<any>> {
+    const req = context.switchToHttp().getRequest();
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction('READ COMMITTED');
+
+    req.queryRunnerManager = queryRunner.manager;
+
+    return next.handle().pipe(
+      map(async data => {
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return data;
+      }),
+      catchError(async err => {
+        await queryRunner.rollbackTransaction();
+        await queryRunner.release();
+
+        throw err;
+      })
+    );
+  }
+}

--- a/back/src/common/interface/request.interface.ts
+++ b/back/src/common/interface/request.interface.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import { EntityManager } from 'typeorm';
 
 export interface JWTRequest extends Request {
   user: {
@@ -8,4 +9,5 @@ export interface JWTRequest extends Request {
   };
 
   hasToken?: boolean;
+  queryRunnerManager?: EntityManager;
 }

--- a/back/src/modules/auth/auth.controller.ts
+++ b/back/src/modules/auth/auth.controller.ts
@@ -117,25 +117,6 @@ export class AuthController {
     res.redirect(`${process.env.OAUTH_REDIRECT_URL}`);
   }
 
-  @Get('test')
-  @ApiResponse({
-    status: 200,
-    description: '로그인 성공'
-  })
-  async test(@Req() req: any, @Res() res: any): Promise<void> {
-    const payload: payload = {
-      id: 3,
-      name: '김부캠',
-      auth_id: '105101728749763412428'
-    };
-    // To DO: refresh token db에 저장 & 클라이언트에는 index만 저장?
-    const { accessToken, refreshToken } =
-      await this.authService.generateJwtToken(payload);
-    await this.authService.saveRefreshToken(payload, refreshToken);
-    this.authService.setCookies(res, accessToken, refreshToken);
-    res.redirect(`${process.env.OAUTH_REDIRECT_URL}`);
-  }
-
   @Get('logout')
   @ApiResponse({
     status: 200,

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserEntity } from '../user/entity/user.entity';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
 export interface payload {
   id: number;
@@ -14,7 +14,8 @@ export class AuthService {
   constructor(
     private readonly jwtService: JwtService,
     @InjectRepository(UserEntity)
-    private readonly UserRepository: Repository<UserEntity>
+    private readonly UserRepository: Repository<UserEntity>,
+    private readonly dataSource: DataSource
   ) {}
 
   async getUserInfo(user: any): Promise<payload> {
@@ -86,15 +87,25 @@ export class AuthService {
   }
 
   async saveRefreshToken(user: any, refreshToken: string): Promise<boolean> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
     try {
-      await this.UserRepository.update(
+      const updateResult = await queryRunner.manager.update(
+        UserEntity,
         { id: user.id },
         { refresh_token: refreshToken }
       );
+      if (!updateResult.affected) {
+        throw new UnauthorizedException('Refresh Token 저장 실패');
+      }
+      await queryRunner.commitTransaction();
     } catch (error) {
+      await queryRunner.rollbackTransaction();
       throw new UnauthorizedException('Refresh Token 저장 실패');
+    } finally {
+      await queryRunner.release();
     }
-
     return true;
   }
 

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -89,7 +89,7 @@ export class AuthService {
   async saveRefreshToken(user: any, refreshToken: string): Promise<boolean> {
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
-    await queryRunner.startTransaction();
+    await queryRunner.startTransaction('READ COMMITTED');
     try {
       const updateResult = await queryRunner.manager.update(
         UserEntity,

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -28,7 +28,6 @@ import {
 import { ResCreateMessageDto } from './dto/response/res-create-message.dto';
 import { MessageDto } from './dto/message.dto';
 import { JWTGuard } from 'src/common/guards/jwt.guard';
-import { UpdateMessageDecorationDto } from './dto/update-message-decoration.dto';
 import { UpdateMessageLocationDto } from './dto/update-message-location.dto';
 import { JWTRequest } from 'src/common/interface/request.interface';
 import { ClovaService } from './clova.service';
@@ -146,36 +145,6 @@ export class MessageController {
     @Param('message_id') message_id: number
   ): Promise<MessageDto> {
     return await this.messageService.openMessage(message_id);
-  }
-
-  @UseGuards(JWTGuard)
-  @ApiCookieAuth('access_token')
-  @Put('/:message_id/decoration')
-  @ApiOperation({
-    summary: '메세지 장식 변경',
-    description: '메시지의 장식을 변경합니다.'
-  })
-  @ApiResponse({
-    status: 200,
-    type: MessageDto
-  })
-  @ApiBadRequestResponse({
-    description: '잘못된 요청입니다.'
-  })
-  @ApiNotFoundResponse({
-    description: '해당 메시지가 존재하지 않습니다.'
-  })
-  @ApiInternalServerErrorResponse({
-    description: '서버측 오류'
-  })
-  async updateMessageDecoration(
-    @Param('message_id') message_id: number,
-    @Body() updateMessageDecorationDto: UpdateMessageDecorationDto
-  ): Promise<UpdateMessageDecorationDto> {
-    return await this.messageService.updateMessageDecoration(
-      message_id,
-      updateMessageDecorationDto
-    );
   }
 
   @UseGuards(JWTGuard)

--- a/back/src/modules/message/message.module.ts
+++ b/back/src/modules/message/message.module.ts
@@ -6,16 +6,10 @@ import { MessageEntity } from './entity/message.entity';
 import { JWTGuard } from '../../common/guards/jwt.guard';
 import { ClovaService } from './clova.service';
 import { LetterEntity } from './entity/letter.entity';
-import { DecorationPrefixEntity } from '../snowball/entity/decoration-prefix.entity';
 import { SnowballEntity } from '../snowball/entity/snowball.entity';
 @Module({
   imports: [
-    TypeOrmModule.forFeature([
-      MessageEntity,
-      SnowballEntity,
-      LetterEntity,
-      DecorationPrefixEntity
-    ])
+    TypeOrmModule.forFeature([MessageEntity, SnowballEntity, LetterEntity])
   ],
   controllers: [MessageController],
   providers: [MessageService, ClovaService, JWTGuard],

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -67,21 +67,19 @@ export class MessageService {
     });
   }
 
-  async isInsertAllowed(snowball_id: number): Promise<boolean> {
+  async isInsertAllowed(snowball_id: number): Promise<void> {
     const messageCount = await this.messageRepository.count({
       where: { snowball_id: snowball_id, is_deleted: false }
     });
     if (messageCount >= 30)
       throw new ConflictException('메세지 갯수가 30개를 초과했습니다');
-    else return true;
   }
 
-  async doesLetterIdExist(letter_id: number): Promise<boolean> {
+  async doesLetterIdExist(letter_id: number): Promise<void> {
     const letter = await this.letterRepository.findOne({
       where: { id: letter_id, active: true }
     });
     if (!letter) throw new NotFoundException('존재하지 않는 letter id입니다');
-    else return true;
   }
 
   async deleteMessage(user_id: number, message_id: number): Promise<void> {

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -68,18 +68,26 @@ export class MessageService {
   }
 
   async isInsertAllowed(snowball_id: number): Promise<void> {
-    const messageCount = await this.messageRepository.count({
-      where: { snowball_id: snowball_id, is_deleted: false }
-    });
-    if (messageCount >= 30)
-      throw new ConflictException('메세지 갯수가 30개를 초과했습니다');
+    try {
+      const messageCount = await this.messageRepository.count({
+        where: { snowball_id: snowball_id, is_deleted: false }
+      });
+      if (messageCount >= 30)
+        throw new ConflictException('메세지 갯수가 30개를 초과했습니다');
+    } catch (err) {
+      throw new InternalServerErrorException('서버 오류');
+    }
   }
 
   async doesLetterIdExist(letter_id: number): Promise<void> {
-    const letter = await this.letterRepository.findOne({
-      where: { id: letter_id, active: true }
-    });
-    if (!letter) throw new NotFoundException('존재하지 않는 letter id입니다');
+    try {
+      const letter = await this.letterRepository.findOne({
+        where: { id: letter_id, active: true }
+      });
+      if (!letter) throw new NotFoundException('존재하지 않는 letter id입니다');
+    } catch (err) {
+      throw new InternalServerErrorException('서버 오류');
+    }
   }
 
   async deleteMessage(user_id: number, message_id: number): Promise<void> {

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -12,11 +12,9 @@ import { ReqCreateMessageDto } from './dto/request/req-create-message.dto';
 import { MessageEntity } from './entity/message.entity';
 import { ResCreateMessageDto } from './dto/response/res-create-message.dto';
 import { MessageDto } from './dto/message.dto';
-import { UpdateMessageDecorationDto } from './dto/update-message-decoration.dto';
 import { UpdateMessageLocationDto } from './dto/update-message-location.dto';
 import { plainToInstance, instanceToPlain } from 'class-transformer';
 import { LetterEntity } from './entity/letter.entity';
-import { DecorationPrefixEntity } from '../snowball/entity/decoration-prefix.entity';
 import { ResClovaSentiment } from './clova.service';
 import { SnowballEntity } from '../snowball/entity/snowball.entity';
 
@@ -28,9 +26,7 @@ export class MessageService {
     @InjectRepository(SnowballEntity)
     private readonly snowballRepository: Repository<SnowballEntity>,
     @InjectRepository(LetterEntity)
-    private readonly letterRepository: Repository<LetterEntity>,
-    @InjectRepository(DecorationPrefixEntity)
-    private readonly messageDecoRepository: Repository<DecorationPrefixEntity>
+    private readonly letterRepository: Repository<LetterEntity>
   ) {}
   async createMessage(
     createMessageDto: ReqCreateMessageDto,
@@ -155,40 +151,6 @@ export class MessageService {
       { groups: ['public'] }
     );
     return messageDto;
-  }
-
-  async updateMessageDecoration(
-    message_id: number,
-    updateMessageDecorationDto: UpdateMessageDecorationDto
-  ): Promise<UpdateMessageDecorationDto> {
-    const { decoration_id, decoration_color } = updateMessageDecorationDto;
-    this.doesDecorationExist(decoration_id);
-
-    const updateResult = await this.messageRepository
-      .createQueryBuilder()
-      .update(MessageEntity)
-      .set({
-        decoration_id,
-        decoration_color
-      })
-      .where('id = :id', { id: message_id, is_deleted: false })
-      .execute();
-    if (!updateResult.affected) {
-      throw new NotFoundException('업데이트할 메시지가 존재하지 않습니다.');
-    } else if (updateResult.affected > 1) {
-      throw new InternalServerErrorException('중복 데이터 오류');
-    }
-    return updateMessageDecorationDto;
-  }
-
-  async doesDecorationExist(decoration_id: number): Promise<boolean> {
-    const decoration = await this.messageDecoRepository.findOne({
-      where: { id: decoration_id, active: true }
-    });
-    if (!decoration) {
-      throw new NotFoundException('업데이트할 장식이 존재하지 않습니다.');
-    }
-    return true;
   }
 
   async updateMessageLocation(

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -90,7 +90,7 @@ export class SnowballService {
 
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
-    await queryRunner.startTransaction();
+    await queryRunner.startTransaction('READ COMMITTED');
 
     try {
       const updateResult = await queryRunner.manager
@@ -168,7 +168,7 @@ export class SnowballService {
 
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
-    await queryRunner.startTransaction();
+    await queryRunner.startTransaction('READ COMMITTED');
 
     try {
       const updateResult = await queryRunner.manager

--- a/back/src/modules/user/user.controller.ts
+++ b/back/src/modules/user/user.controller.ts
@@ -5,7 +5,8 @@ import {
   UseGuards,
   Param,
   Req,
-  Put
+  Put,
+  UseInterceptors
 } from '@nestjs/common';
 import { JWTGuard } from '../../common/guards/jwt.guard';
 import {
@@ -19,6 +20,7 @@ import { UserService } from './user.service';
 import { ResInfoDto } from './dto/response/res-info.dto';
 import { NicknameDto } from './dto/nickname.dto';
 import { JWTRequest } from 'src/common/interface/request.interface';
+import { TransactionInterceptor } from 'src/common/interceptors/transaction.interceptor';
 
 @ApiTags('User API')
 @Controller('user')
@@ -60,6 +62,7 @@ export class UserController {
   }
 
   @UseGuards(JWTGuard)
+  @UseInterceptors(TransactionInterceptor)
   @ApiCookieAuth('access_token')
   @Put('/nickname')
   @ApiBody({ type: NicknameDto })
@@ -73,10 +76,10 @@ export class UserController {
     type: NicknameDto
   })
   async updateNickname(
-    @Req() req: JWTRequest,
+    @Req() req: any,
     @Body() nicknameDto: NicknameDto
   ): Promise<NicknameDto> {
-    const result = this.userService.updateNickname(req.user.id, nicknameDto);
+    const result = this.userService.updateNickname(req, nicknameDto);
     return result;
   }
 }

--- a/back/src/modules/user/user.controller.ts
+++ b/back/src/modules/user/user.controller.ts
@@ -76,7 +76,7 @@ export class UserController {
     type: NicknameDto
   })
   async updateNickname(
-    @Req() req: any,
+    @Req() req: JWTRequest,
     @Body() nicknameDto: NicknameDto
   ): Promise<NicknameDto> {
     const result = this.userService.updateNickname(req, nicknameDto);

--- a/back/src/modules/user/user.service.ts
+++ b/back/src/modules/user/user.service.ts
@@ -94,7 +94,7 @@ export class UserService {
   ): Promise<NicknameDto> {
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
-    await queryRunner.startTransaction();
+    await queryRunner.startTransaction('READ COMMITTED');
     try {
       const updateResult = await queryRunner.manager
         .createQueryBuilder()


### PR DESCRIPTION
## 💡 완료된 기능
- [x] 각 서비스 로직 중 create, insert, delete 에 트랜잭션 적용

- 트랜잭션을 적용하는 방법은 네가지가 있음
- @Transactional
- getManager().transaction()
- save() 함수
- queryRunner

이 중, 데코레이터는 권장되지 않는 방식임
queryRunner가 가장 확장성이 좋아보여 선택함
하지만 save()함수의 편리성도 있기에, **반드시 insert/update 중 한가지가 보장되는 상황**에는 save()함수를 사용했음
save()함수는 추가적으로 select 쿼리를 생성하는데, 이를 막기 위해 reload:false로 옵션을 지정함

나머지는 queryRunner로 작성함
격리 수준은 Read Committed로 설정 << 공부 필요
고립 수준을 지정해야하는 문제가 생긴다면 save() 함수도 queryRunner로 변경 예정

인터셉터를 만들긴 했는데, 컨트롤러 단위로 적용이 가능해서 자칫하면 트랜잭션 범위가 커져 성능 저하가 우려됨
side effect가 없을만한 단순한 컨트롤러에만 트랜잭션 인터셉터를 적용했음