### PR TITLE
[송현우] api throttler 구현

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -25,6 +25,7 @@
         "class-validator": "^0.14.0",
         "dotenv": "^16.3.1",
         "express-basic-auth": "^1.2.1",
+        "k6": "^0.0.0",
         "mysql2": "^3.6.3",
         "passport": "^0.6.0",
         "passport-facebook": "^3.0.0",
@@ -7094,6 +7095,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha512-GAQSWayS2+LjbH5bkRi+pMPYyP1JSp7o+4j58ANZ762N/RH/SdlAT3CHHztnn8s/xgg8kYNM24Gd2IPo9b5W+g=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -16201,6 +16207,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha512-GAQSWayS2+LjbH5bkRi+pMPYyP1JSp7o+4j58ANZ762N/RH/SdlAT3CHHztnn8s/xgg8kYNM24Gd2IPo9b5W+g=="
     },
     "keyv": {
       "version": "4.5.4",

--- a/back/package.json
+++ b/back/package.json
@@ -36,6 +36,7 @@
     "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",
     "express-basic-auth": "^1.2.1",
+    "k6": "^0.0.0",
     "mysql2": "^3.6.3",
     "passport": "^0.6.0",
     "passport-facebook": "^3.0.0",

--- a/back/src/common/guards/throttler.guard.ts
+++ b/back/src/common/guards/throttler.guard.ts
@@ -4,10 +4,8 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
   protected async getTracker(req: Record<string, any>): Promise<string> {
-    console.log('req.ip = ', req.ip);
-    console.log('req.ips = ', req.ips);
-    const forwardedFor = req.headers['x-forwarded-for'];
-    console.log('forwardedFor = ', forwardedFor);
-    return req.ips.length ? req.ips[0] : req.ip;
+    const client_ip = req.headers['x-forwarded-for'];
+    console.log('client_ip = ', client_ip);
+    return client_ip || req.ip;
   }
 }

--- a/back/src/config/throttler-config.ts
+++ b/back/src/config/throttler-config.ts
@@ -3,11 +3,17 @@ import { ThrottlerModuleOptions } from '@nestjs/throttler';
 const throttlerConfig: ThrottlerModuleOptions = {
   throttlers: [
     {
+      name: 'api',
       ttl: 10000, // 10 seconds
-      limit: 30
+      limit: 30,
+      skipIf: context => {
+        // api route로 시작하지 않는 요청은 제외
+        const req = context.switchToHttp().getRequest();
+        return req.route.path.startsWith('/api') ? false : true;
+      }
     }
   ],
-  errorMessage: 'Too Many Requests'
+  errorMessage: 'Too Many API Requests'
 };
 
 export default throttlerConfig;

--- a/back/src/config/throttler-config.ts
+++ b/back/src/config/throttler-config.ts
@@ -4,7 +4,7 @@ const throttlerConfig: ThrottlerModuleOptions = {
   throttlers: [
     {
       name: 'api',
-      ttl: 5000, // 5 seconds
+      ttl: 1000, // 5 seconds
       limit: 5
     }
   ],

--- a/back/src/config/throttler-config.ts
+++ b/back/src/config/throttler-config.ts
@@ -4,8 +4,8 @@ const throttlerConfig: ThrottlerModuleOptions = {
   throttlers: [
     {
       name: 'api',
-      ttl: 10000, // 10 seconds
-      limit: 30
+      ttl: 5000, // 5 seconds
+      limit: 5
     }
   ],
   errorMessage: 'Too Many API Requests'

--- a/back/src/config/throttler-config.ts
+++ b/back/src/config/throttler-config.ts
@@ -5,12 +5,7 @@ const throttlerConfig: ThrottlerModuleOptions = {
     {
       name: 'api',
       ttl: 10000, // 10 seconds
-      limit: 30,
-      skipIf: context => {
-        // api route로 시작하지 않는 요청은 제외
-        const req = context.switchToHttp().getRequest();
-        return req.route.path.startsWith('/api') ? false : true;
-      }
+      limit: 30
     }
   ],
   errorMessage: 'Too Many API Requests'

--- a/back/src/config/throttler-config.ts
+++ b/back/src/config/throttler-config.ts
@@ -3,8 +3,8 @@ import { ThrottlerModuleOptions } from '@nestjs/throttler';
 const throttlerConfig: ThrottlerModuleOptions = {
   throttlers: [
     {
-      ttl: 10,
-      limit: 3
+      ttl: 10000, // 10 seconds
+      limit: 30
     }
   ],
   errorMessage: 'Too Many Requests'

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserEntity } from '../user/entity/user.entity';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Response } from 'express';
 
 export interface payload {
@@ -15,8 +15,7 @@ export class AuthService {
   constructor(
     private readonly jwtService: JwtService,
     @InjectRepository(UserEntity)
-    private readonly UserRepository: Repository<UserEntity>,
-    private readonly dataSource: DataSource
+    private readonly UserRepository: Repository<UserEntity>
   ) {}
 
   async getUserInfo(user: any): Promise<payload> {

--- a/back/src/modules/auth/auth.service.ts
+++ b/back/src/modules/auth/auth.service.ts
@@ -102,24 +102,15 @@ export class AuthService {
   }
 
   async saveRefreshToken(user: any, refreshToken: string): Promise<boolean> {
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction('READ COMMITTED');
-    try {
-      const updateResult = await queryRunner.manager.update(
-        UserEntity,
-        { id: user.id },
-        { refresh_token: refreshToken }
-      );
-      if (!updateResult.affected) {
-        throw new UnauthorizedException('Refresh Token 저장 실패');
-      }
-      await queryRunner.commitTransaction();
-    } catch (error) {
-      await queryRunner.rollbackTransaction();
+    const updateResult = await this.UserRepository.createQueryBuilder()
+      .update(UserEntity)
+      .set({
+        refresh_token: refreshToken
+      })
+      .where('id = :id', { id: user.id })
+      .execute();
+    if (!updateResult.affected) {
       throw new UnauthorizedException('Refresh Token 저장 실패');
-    } finally {
-      await queryRunner.release();
     }
     return true;
   }

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -122,7 +122,7 @@ export class MessageController {
   }
 
   @UseGuards(JWTGuard)
-  @Throttle({ api: { limit: 30, ttl: 5000 } })
+  @Throttle({ api: { limit: 10, ttl: 1000 } })
   @ApiCookieAuth('access_token')
   @Put('/:message_id/open')
   @HttpCode(200)

--- a/back/src/modules/message/message.controller.ts
+++ b/back/src/modules/message/message.controller.ts
@@ -31,6 +31,7 @@ import { JWTGuard } from 'src/common/guards/jwt.guard';
 import { JWTRequest } from 'src/common/interface/request.interface';
 import { ClovaService } from './clova.service';
 import { UpdateMessageLocationsDto } from './dto/update-message-locations.dto';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('Message API')
 @Controller('message')
@@ -121,6 +122,7 @@ export class MessageController {
   }
 
   @UseGuards(JWTGuard)
+  @Throttle({ api: { limit: 30, ttl: 5000 } })
   @ApiCookieAuth('access_token')
   @Put('/:message_id/open')
   @HttpCode(200)

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -56,24 +56,21 @@ export class MessageService {
       ...createMessageDto
     });
     try {
-      await this.messageRepository.save(messageEntity, {
-        transaction: false,
-        reload: false
+      const resCreateMessage = await this.messageRepository.save(
+        messageEntity,
+        {
+          transaction: false,
+          reload: false
+        }
+      );
+      console.log(resCreateMessage);
+      return plainToInstance(ResCreateMessageDto, resCreateMessage, {
+        excludeExtraneousValues: true
       });
     } catch (err) {
       console.log(err);
       throw new BadRequestException('Insert Fail');
     }
-
-    const resCreateMessage = {
-      ...createMessageDto,
-      ...resClovaSentiment,
-      location: location
-    };
-
-    return plainToInstance(ResCreateMessageDto, resCreateMessage, {
-      excludeExtraneousValues: true
-    });
   }
 
   async isInsertAllowed(snowball_id: number): Promise<void> {

--- a/back/src/modules/message/message.service.ts
+++ b/back/src/modules/message/message.service.ts
@@ -58,6 +58,7 @@ export class MessageService {
     });
     try {
       await this.messageRepository.save(messageEntity, {
+        transaction: false,
         reload: false
       });
     } catch (err) {
@@ -126,7 +127,7 @@ export class MessageService {
     }
     await this.messageRepository.save(
       { id: message_id, is_deleted: new Date() },
-      { reload: false }
+      { transaction: false, reload: false }
     );
   }
 
@@ -167,7 +168,7 @@ export class MessageService {
     }
     await this.messageRepository.save(
       { id: message_id, opened: new Date() },
-      { reload: false }
+      { transaction: false, reload: false }
     );
     const messageDto = plainToInstance(
       MessageDto,

--- a/back/src/modules/snowball/snowball.controller.ts
+++ b/back/src/modules/snowball/snowball.controller.ts
@@ -28,6 +28,7 @@ import { JWTGuard } from '../../common/guards/jwt.guard';
 import { UpdateMainDecoDto } from './dto/update-main-decoration.dto';
 import { JWTRequest } from '../../common/interface/request.interface';
 import { hasJWTInterceptor } from '../../common/interceptors/hasJwt.interceptor';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('Snowball API')
 @Controller('snowball')
@@ -86,6 +87,7 @@ export class SnowballController {
   }
 
   @Get('/:snowball_id')
+  @Throttle({ api: { limit: 30, ttl: 5000 } })
   @UseInterceptors(hasJWTInterceptor)
   @HttpCode(200)
   @ApiResponse({

--- a/back/src/modules/snowball/snowball.controller.ts
+++ b/back/src/modules/snowball/snowball.controller.ts
@@ -87,7 +87,7 @@ export class SnowballController {
   }
 
   @Get('/:snowball_id')
-  @Throttle({ api: { limit: 30, ttl: 5000 } })
+  @Throttle({ api: { limit: 10, ttl: 1000 } })
   @UseInterceptors(hasJWTInterceptor)
   @HttpCode(200)
   @ApiResponse({

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { SnowballEntity } from './entity/snowball.entity';
 import { ReqCreateSnowballDto } from './dto/request/req-create-snowball.dto';
 import { ReqUpdateSnowballDto } from './dto/request/req-update-snowball.dto';
@@ -30,8 +30,7 @@ export class SnowballService {
     @InjectRepository(SnowballEntity)
     private readonly snowballRepository: Repository<SnowballEntity>,
     @InjectRepository(DecorationPrefixEntity)
-    private readonly snowballDecoRepository: Repository<DecorationPrefixEntity>,
-    private readonly dataSource: DataSource
+    private readonly snowballDecoRepository: Repository<DecorationPrefixEntity>
   ) {}
 
   async createSnowball(

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -88,31 +88,20 @@ export class SnowballService {
     const { title, is_message_private } = updateSnowballDto;
     await this.doesSnowballExist(snowball_id);
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction('READ COMMITTED');
-
-    try {
-      const updateResult = await queryRunner.manager
-        .createQueryBuilder()
-        .update(SnowballEntity)
-        .set({
-          title,
-          is_message_private: is_message_private ? new Date() : null
-        })
-        .where('id = :id', { id: snowball_id })
-        .andWhere('user_id = :user_id', { user_id: user_id })
-        .execute();
-      if (!updateResult.affected) {
-        throw new NotFoundException('스노우볼 업데이트 실패');
-      }
-      await queryRunner.commitTransaction();
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
+    const updateResult = await this.snowballRepository
+      .createQueryBuilder()
+      .update(SnowballEntity)
+      .set({
+        title,
+        is_message_private: is_message_private ? new Date() : null
+      })
+      .where('id = :id', { id: snowball_id })
+      .andWhere('user_id = :user_id', { user_id: user_id })
+      .execute();
+    if (!updateResult.affected) {
+      throw new NotFoundException('스노우볼 업데이트 실패');
     }
+
     const resUpdateSnowballDto = {
       snowball_id,
       ...updateSnowballDto
@@ -166,31 +155,20 @@ export class SnowballService {
     await this.doesDecorationExist(updateMainDecoDto.main_decoration_id);
     await this.doesDecorationExist(updateMainDecoDto.bottom_decoration_id);
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction('READ COMMITTED');
+    const updateResult = await this.snowballRepository
+      .createQueryBuilder()
+      .update(SnowballEntity)
+      .set({
+        ...updateMainDecoDto
+      })
+      .where('id = :id', { id: snowball_id })
+      .andWhere('user_id = :user_id', { user_id: user_id })
+      .execute();
 
-    try {
-      const updateResult = await queryRunner.manager
-        .createQueryBuilder()
-        .update(SnowballEntity)
-        .set({
-          ...updateMainDecoDto
-        })
-        .where('id = :id', { id: snowball_id })
-        .andWhere('user_id = :user_id', { user_id: user_id })
-        .execute();
-
-      if (!updateResult.affected) {
-        throw new NotFoundException('스노우볼을 업데이트 실패');
-      }
-      await queryRunner.commitTransaction();
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
+    if (!updateResult.affected) {
+      throw new NotFoundException('스노우볼을 업데이트 실패');
     }
+
     return updateMainDecoDto;
   }
 

--- a/back/src/modules/snowball/snowball.service.ts
+++ b/back/src/modules/snowball/snowball.service.ts
@@ -49,7 +49,10 @@ export class SnowballService {
       ...createSnowballDto
     });
 
-    const savedSnowballEntity = await this.snowballRepository.save(snowball);
+    const savedSnowballEntity = await this.snowballRepository.save(snowball, {
+      reload: false,
+      transaction: false
+    });
     const savedSnowball = instanceToPlain(savedSnowballEntity);
 
     const combinedSnowballDto = {

--- a/back/src/modules/user/user.controller.ts
+++ b/back/src/modules/user/user.controller.ts
@@ -5,8 +5,7 @@ import {
   UseGuards,
   Param,
   Req,
-  Put,
-  UseInterceptors
+  Put
 } from '@nestjs/common';
 import { JWTGuard } from '../../common/guards/jwt.guard';
 import {
@@ -20,7 +19,6 @@ import { UserService } from './user.service';
 import { ResInfoDto } from './dto/response/res-info.dto';
 import { NicknameDto } from './dto/nickname.dto';
 import { JWTRequest } from 'src/common/interface/request.interface';
-import { TransactionInterceptor } from 'src/common/interceptors/transaction.interceptor';
 
 @ApiTags('User API')
 @Controller('user')
@@ -62,7 +60,6 @@ export class UserController {
   }
 
   @UseGuards(JWTGuard)
-  @UseInterceptors(TransactionInterceptor)
   @ApiCookieAuth('access_token')
   @Put('/nickname')
   @ApiBody({ type: NicknameDto })

--- a/back/src/modules/user/user.service.ts
+++ b/back/src/modules/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { UserEntity } from './entity/user.entity';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ResInfoDto } from './dto/response/res-info.dto';
 import { UserDto } from './dto/user.dto';
@@ -20,8 +20,7 @@ export class UserService {
   constructor(
     private readonly snowballService: SnowballService,
     @InjectRepository(UserEntity)
-    private readonly userRepository: Repository<UserEntity>,
-    private readonly dataSource: DataSource
+    private readonly userRepository: Repository<UserEntity>
   ) {}
 
   async getUserData(auth_id: string): Promise<userData> {


### PR DESCRIPTION
## 💡 완료된 기능
- [x] api throttler 구현

### 구현 과정

1.  nginx로 reverse proxy를 하기 떄문에 req.ip를 받으면 10.0.1.6이 반환됨
-> req.headers['x-forwarded-for'];에 담기는 client ip를 받아서 반환하도록 ThrottlerBehindProxyGuard 구현

2. throttlerConfig를 따로 분리함. 그리고 config상에서도 throttlers를 여러개로 분리할까 했지만, skipIf 로직이 모든 컨트롤러 마다 발생하는 문제가 생겨 @Throttle() 데코레이터를 라우터 단에서 활용하기로 함.

3. 기본 1초당 5회 제한을 걸어두고, 자주 사용하는(연속으로 요청할 일이 잦은) 스노우볼 조회 및 메세지 오픈처리 api만 10회 제한으로 변경

4. ThrottlerBehindProxyGuard 의 리턴값으로 구분이 잘 되는 지 테스트하기 위해 randomUUID()를 생성하여 반환하고 동작해본 결과 잘 동작함!

## 📷 완료된 기능 사진
### ip 출력 확인
![reverse proxy ip 겟](https://github.com/boostcampwm2023/web11-SSOCK/assets/83938394/0952c0b0-a348-4012-b08b-2589613e9076)
### postman 테스트 시 에러 코드 정상 출력
![에러 코드 정상 출력](https://github.com/boostcampwm2023/web11-SSOCK/assets/83938394/059378b5-639e-43eb-a50e-45c240bf88ae)