### PR TITLE
[김찬우] 메타 태그, img alt 속성 추가 및 청크 크기 분리

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -13,6 +13,9 @@
       property="og:description"
       content="나만의 스노우볼을 만들어보세요 !"
     />
+    <meta name="description" content="나만의 스노우볼을 만들어보세요 !" />
+    <meta name="author" content="SSOCK" />
+
     <title>스노우볼 속 내 마음</title>
   </head>
   <body>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/react": "^7.86.0",
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.29",
-        "@types/three": "^0.158.1",
+        "@types/three": "^0.158.3",
         "axios": "^1.6.2",
         "react": "^18.2.0",
         "react-cookie": "^6.1.1",
@@ -21,7 +21,8 @@
         "react-router-dom": "^6.18.0",
         "styled-components": "^6.1.0",
         "styled-reset": "^4.5.1",
-        "three": "^0.158.0"
+        "three": "^0.158.0",
+        "vite-plugin-compression2": "^0.11.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
@@ -885,6 +886,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sentry-internal/feedback": {
       "version": "7.86.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.86.0.tgz",
@@ -1209,6 +1231,11 @@
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.8.tgz",
       "integrity": "sha512-hdA2gODc+1X5gG+buH8gMRnQdRTa3vep8+PyGFK9xDQmbdudobP//yXLK+C/SnjGLWHiER2QL+xWjq7qkFuivA=="
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
     "node_modules/@types/history": {
       "version": "4.7.11",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
@@ -1317,9 +1344,9 @@
       "integrity": "sha512-Rm17MsTpQQP5Jq4BF7CdrxJsDufoiL/q5IbJZYZmOZAJALyijgF7BzLgobXUqraNcQdqFYLYGeglDp6QzaxPpg=="
     },
     "node_modules/@types/three": {
-      "version": "0.158.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.158.1.tgz",
-      "integrity": "sha512-U7SimpoMrlpY2TjYedb9sQeOVHdRWJEiaNQxywJETMGMoEhWEfpP0sywRADR/xOQbaixZ6lk5Hv+3IOFriprkw==",
+      "version": "0.158.3",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.158.3.tgz",
+      "integrity": "sha512-6Qs1rUvLSbkJ4hlIe6/rdwIf61j1x2UKvGJg7s8KjswYsz1C1qDTs6voVXXB8kYaI0hgklgZgbZUupfL1l9xdA==",
       "dependencies": {
         "@types/stats.js": "*",
         "@types/webxr": "*",
@@ -2149,6 +2176,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2897,7 +2929,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3172,7 +3203,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -3593,6 +3624,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-compression2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression2/-/vite-plugin-compression2-0.11.0.tgz",
+      "integrity": "sha512-U6oEyRXZD26BynOgD/tStNTbQOLPt96aQNj/gdJTicKVYCQCdlV7QdmSF7VEhSyjiS59pQRhiMBu/uajprxWLA==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.2"
       }
     },
     "node_modules/vite-plugin-mkcert": {

--- a/front/package.json
+++ b/front/package.json
@@ -15,7 +15,7 @@
     "@sentry/react": "^7.86.0",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.29",
-    "@types/three": "^0.158.1",
+    "@types/three": "^0.158.3",
     "axios": "^1.6.2",
     "react": "^18.2.0",
     "react-cookie": "^6.1.1",
@@ -23,7 +23,8 @@
     "react-router-dom": "^6.18.0",
     "styled-components": "^6.1.0",
     "styled-reset": "^4.5.1",
-    "three": "^0.158.0"
+    "three": "^0.158.0",
+    "vite-plugin-compression2": "^0.11.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,9 +1,8 @@
 import { BrowserRouter, Routes, Route, Outlet } from 'react-router-dom';
-import * as Sentry from '@sentry/react';
+import { ErrorBoundary } from '@sentry/react';
 import styled, { ThemeProvider } from 'styled-components';
 import GlobalStyles from './GlobalStyles';
 import { theme } from '@utils';
-// import * as Pages from '@pages';
 import { Song } from '@components';
 import { HasSnowballData } from './router';
 import { SnowBallProvider } from '@pages/Visit/SnowBallProvider';
@@ -36,7 +35,7 @@ const Wrong = lazy(() => import('@pages/Wrong/Wrong'));
 const App = () => {
   return (
     <>
-      <Sentry.ErrorBoundary>
+      <ErrorBoundary>
         <GlobalStyles />
         <ThemeProvider theme={theme}>
           <Outer>
@@ -103,7 +102,7 @@ const App = () => {
             </Suspense>
           </Outer>
         </ThemeProvider>
-      </Sentry.ErrorBoundary>
+      </ErrorBoundary>
     </>
   );
 };

--- a/front/src/components/SnowGlobeCanvas/Decos.tsx
+++ b/front/src/components/SnowGlobeCanvas/Decos.tsx
@@ -1,10 +1,11 @@
 import { useContext } from 'react';
-import { getDecoPoisition } from '@utils';
+import { getDecoPosition } from '@utils';
 import * as Models from './models';
 import { MessageListContext } from '@pages/Visit/MessageListProvider';
+import { Vector3 } from 'three';
 
 interface DecosProps {
-  centerPosition: THREE.Vector3;
+  centerPosition: Vector3;
   radius: number;
 }
 
@@ -16,7 +17,7 @@ const Decos = ({ centerPosition, radius }: DecosProps) => {
       key={index}
       id={message.decoration_id}
       scale={1}
-      position={getDecoPoisition(message.location)}
+      position={getDecoPosition(message.location)}
       message={message.content ?? '비공개 메시지 입니다.'}
       color={message.decoration_color}
       sender={message.sender ?? '비공개'}

--- a/front/src/components/SnowGlobeCanvas/SnowGlobeCanvas.tsx
+++ b/front/src/components/SnowGlobeCanvas/SnowGlobeCanvas.tsx
@@ -1,7 +1,8 @@
 import React, { useRef } from 'react';
-import { OrbitControls } from '@react-three/drei';
+import { OrbitControls } from '@react-three/drei/core/OrbitControls';
 import { Canvas } from '@react-three/fiber';
-import * as THREE from 'three';
+import {Vector3, Color} from 'three';
+
 import { CanvasContainer } from '@utils';
 import * as Models from './models';
 import { Prev } from '../Prev';
@@ -17,7 +18,7 @@ const SnowGlobeCanvas = React.memo<SnowGlobeCanvasProps>(
   ({ snowBallData }) => {
     const isClicked = useRef<boolean>(false);
     const glassRadius = 7;
-    const glassPosition = new THREE.Vector3(0, glassRadius / 2, 0);
+    const glassPosition = new Vector3(0, glassRadius / 2, 0);
 
     const snows = Array.from({ length: 100 }, (_, i) => (
       <Models.Snow
@@ -40,7 +41,7 @@ const SnowGlobeCanvas = React.memo<SnowGlobeCanvasProps>(
             shadows={true}
           >
             <OrbitControls
-              target={new THREE.Vector3(0, 2, 0)}
+              target={new Vector3(0, 2, 0)}
               enablePan={false}
               enableZoom={false}
               maxPolarAngle={Math.PI / 2}
@@ -67,30 +68,30 @@ const SnowGlobeCanvas = React.memo<SnowGlobeCanvasProps>(
             />
 
             <Models.Raycaster isClickedRef={isClicked} />
-            <Models.Ground scale={1} position={new THREE.Vector3(0, 0, 0)} />
+            <Models.Ground scale={1} position={new Vector3(0, 0, 0)} />
             <Models.Glass
               position={glassPosition}
-              color={new THREE.Color('white')}
+              color={new Color('white')}
               radius={glassRadius}
               opacity={0.1}
             />
             <Models.MainDeco
               id={snowBallData.main_decoration_id}
               scale={1}
-              position={new THREE.Vector3(0, 10, 0)}
+              position={new Vector3(0, 10, 0)}
               color={snowBallData.main_decoration_color}
             />
             <Models.Bottom
               bottomID={snowBallData.bottom_decoration_id}
               scale={1}
-              position={new THREE.Vector3(0, 0, 0)}
+              position={new Vector3(0, 0, 0)}
               title={snowBallData.title}
-              color={new THREE.Color(snowBallData.bottom_decoration_color)}
+              color={new Color(snowBallData.bottom_decoration_color)}
             />
             {snows}
 
             <Decos
-              centerPosition={new THREE.Vector3(0, glassRadius / 2, 0)}
+              centerPosition={new Vector3(0, glassRadius / 2, 0)}
               radius={glassRadius}
             />
           </Canvas>

--- a/front/src/components/SnowGlobeCanvas/models/Bottom.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Bottom.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Vector3, Color, Mesh, MeshStandardMaterial } from 'three';
 import * as MeshUtils from '@utils/meshUtils';
 import { BOTTOM } from '@constants';
 
 interface BottomProps {
   scale: number;
-  position: THREE.Vector3;
+  position: Vector3;
   bottomID: number;
   title: string;
-  color: THREE.Color;
+  color: Color;
 }
 
 const Bottom: React.FC<BottomProps> = ({
@@ -20,8 +20,8 @@ const Bottom: React.FC<BottomProps> = ({
   color
 }) => {
   const bottom = useGLTF(BOTTOM[bottomID].fileName).scene.clone();
-  const nameTag = bottom.getObjectByName('nameTag') as THREE.Mesh;
-  if (nameTag && nameTag.material instanceof THREE.MeshStandardMaterial) {
+  const nameTag = bottom.getObjectByName('nameTag') as Mesh;
+  if (nameTag && nameTag.material instanceof MeshStandardMaterial) {
     const newTexture = MeshUtils.makeCanvasTexture({
       string: title,
       width: 1024,
@@ -35,9 +35,9 @@ const Bottom: React.FC<BottomProps> = ({
     nameTag.material.bumpMap = newTexture;
   }
 
-  const mainColor = bottom.getObjectByName('mainColor') as THREE.Mesh;
+  const mainColor = bottom.getObjectByName('mainColor') as Mesh;
   if (mainColor) {
-    const material = mainColor.material as THREE.MeshStandardMaterial;
+    const material = mainColor.material as MeshStandardMaterial;
     material.color = color;
   }
 

--- a/front/src/components/SnowGlobeCanvas/models/Deco.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Deco.tsx
@@ -1,12 +1,12 @@
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Vector3, Group, Object3DEventMap, Mesh } from 'three';
 import * as MeshUtils from '@utils/meshUtils';
 import { DECO, MSG_COLOR } from '@constants';
 
 interface DecoProps {
   id: number;
   scale: number;
-  position: THREE.Vector3;
+  position: Vector3;
   message: string;
   color: string;
   sender: string;
@@ -15,7 +15,7 @@ interface DecoProps {
   messageID: number;
 }
 
-const DecoSet = (deco: THREE.Group<THREE.Object3DEventMap>) => {
+const DecoSet = (deco: Group<Object3DEventMap>) => {
   const newModel = useGLTF('/models/new.glb').scene.clone().children[0];
   newModel.position.set(0, 1.2, 0);
   newModel.scale.set(0.1, 0.1, 0.1);
@@ -45,7 +45,7 @@ const Deco = ({
   }
 
   deco.children.forEach(child => {
-    if (child instanceof THREE.Mesh) {
+    if (child instanceof Mesh) {
       child.userData.message = message;
       child.userData.sender = sender;
       child.userData.color = color;

--- a/front/src/components/SnowGlobeCanvas/models/Emoji.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Emoji.tsx
@@ -1,19 +1,19 @@
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Mesh, Group, Vector3 } from 'three';
 import { SENTIMENT_MODEL } from '@constants';
 
 interface SnowProps {
-  centerPosition: THREE.Vector3;
+  centerPosition: Vector3;
   rangeRadius: number;
   sentiment: 'positive' | 'neutral' | 'negative';
   confidence: number;
 }
 
 const randomizePosition = (
-  target: THREE.Mesh | THREE.Group,
-  centerPosition: THREE.Vector3,
+  target: Mesh | Group,
+  centerPosition: Vector3,
   radius: number
 ) => {
   const x =
@@ -29,9 +29,9 @@ const randomizePosition = (
 };
 
 const fallingAnimate = (
-  target: THREE.Mesh,
+  target: Mesh,
   speed: number,
-  centerPosition: THREE.Vector3,
+  centerPosition: Vector3,
   radius: number
 ) => {
   if (target.position.y <= -1) {
@@ -40,13 +40,13 @@ const fallingAnimate = (
   target.position.y -= speed;
 };
 
-const rotateAnimate = (target: THREE.Mesh, speed: number) => {
+const rotateAnimate = (target: Mesh, speed: number) => {
   target.rotation.y += speed;
 };
 
 const visibleInRange = (
-  target: THREE.Mesh,
-  centerPosition: THREE.Vector3,
+  target: Mesh,
+  centerPosition: Vector3,
   radius: number
 ) => {
   target.visible =
@@ -59,7 +59,7 @@ const Emoji: React.FC<SnowProps> = ({
   sentiment,
   confidence
 }) => {
-  const snowRef = useRef<THREE.Mesh>(null);
+  const snowRef = useRef<Mesh>(null);
   const index = sentiment === 'positive' ? 1 : sentiment === 'neutral' ? 2 : 3;
   const snow = useGLTF(SENTIMENT_MODEL[index].fileName).scene.clone();
   const scale = 0.3 + confidence / 200; // min 0.3 max 0.8

--- a/front/src/components/SnowGlobeCanvas/models/Glass.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Glass.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import * as THREE from 'three';
+import { Vector3, Color } from 'three';
 
 interface GlassProps {
-  position: THREE.Vector3;
+  position: Vector3;
   radius: number;
-  color: THREE.Color;
+  color: Color;
   opacity: number;
 }
 

--- a/front/src/components/SnowGlobeCanvas/models/Ground.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Ground.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Vector3 } from 'three';
 
 interface GroundProps {
   scale: number;
-  position: THREE.Vector3;
+  position: Vector3;
 }
 
 const Ground: React.FC<GroundProps> = ({ scale, position }) => {

--- a/front/src/components/SnowGlobeCanvas/models/MainDeco.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/MainDeco.tsx
@@ -1,22 +1,22 @@
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect, MutableRefObject } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Vector3, Object3D, Mesh } from 'three';
 import { makeColorChangedMaterial } from '@utils/meshUtils';
 import { MAIN } from '@constants';
 
 interface MyModelProps {
   id: number;
   scale: number;
-  position: THREE.Vector3;
+  position: Vector3;
   color: string;
 }
 
 const fallingModel = (
-  modelRef: THREE.Object3D | null,
-  speedRef: React.MutableRefObject<THREE.Vector3>,
+  modelRef: Object3D | null,
+  speedRef: MutableRefObject<Vector3>,
   delta: number,
-  isStoppedRef: React.MutableRefObject<boolean>
+  isStoppedRef: MutableRefObject<boolean>
 ) => {
   const airResistance = 0.02;
   const acceleration = 0.3 * delta; //가속도
@@ -38,7 +38,7 @@ const fallingModel = (
 
 const MainDeco = ({ id, scale, position, color }: MyModelProps) => {
   const deco = useGLTF(MAIN[id].fileName).scene.clone();
-  const speedRef = useRef<THREE.Vector3>(new THREE.Vector3(0, 0, 0));
+  const speedRef = useRef<Vector3>(new Vector3(0, 0, 0));
   const isStoppedRef = useRef<boolean>(false);
 
   useEffect(() => {
@@ -50,11 +50,10 @@ const MainDeco = ({ id, scale, position, color }: MyModelProps) => {
   deco.position.set(position.x, position.y, position.z);
   deco.children.forEach(mesh => (mesh.castShadow = true));
 
-  const colorPart = deco.getObjectByName('colorPart') as THREE.Mesh;
+  const colorPart = deco.getObjectByName('colorPart') as Mesh;
   colorPart.material = makeColorChangedMaterial(colorPart, color);
 
   useFrame((_, delta) => {
-    //이거 1초에 1프레임도 안나오면 메인장식 멈출수도있음
     if (delta > 1) {
       delta = 0;
     }

--- a/front/src/components/SnowGlobeCanvas/models/Raycaster.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Raycaster.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useRef, useContext } from 'react';
+import { useEffect, useRef, useContext, FC, MutableRefObject } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
-import * as THREE from 'three';
+import { Vector3 } from "three";
 import { MessageContext } from '@pages/Visit/MessageProvider';
 import { PrevContext } from '../PrevProvider';
 
 interface RaycasterProps {
-  isClickedRef: React.MutableRefObject<boolean>;
+  isClickedRef: MutableRefObject<boolean>;
 }
 
-const Raycaster: React.FC<RaycasterProps> = ({ isClickedRef }) => {
+const Raycaster: FC<RaycasterProps> = ({ isClickedRef }) => {
   const { camera, pointer, raycaster, scene, gl } = useThree();
   const { setMessage, setSender, setColor, setMessageID } =
     useContext(MessageContext);
@@ -23,7 +23,7 @@ const Raycaster: React.FC<RaycasterProps> = ({ isClickedRef }) => {
     if (isAnimating.current) {
       if (isClicked && !isZoom) {
         setView(true);
-        const targetPosition = new THREE.Vector3(0, 2.5, 0);
+        const targetPosition = new Vector3(0, 2.5, 0);
         camera.position.distanceTo(targetPosition) > 6
           ? camera.position.lerp(targetPosition, delta * 2)
           : (isAnimating.current = false);
@@ -34,7 +34,7 @@ const Raycaster: React.FC<RaycasterProps> = ({ isClickedRef }) => {
       if (view) {
         setIsZoom(true);
       } else if (isZoom && !view) {
-        if (camera.position.distanceTo(new THREE.Vector3(0, 3.5, 0)) < 15) {
+        if (camera.position.distanceTo(new Vector3(0, 3.5, 0)) < 15) {
           camera.position.x *= zoomOutSpeed;
           camera.position.y *= zoomOutSpeed;
           camera.position.z *= zoomOutSpeed;

--- a/front/src/components/SnowGlobeCanvas/models/Snow.tsx
+++ b/front/src/components/SnowGlobeCanvas/models/Snow.tsx
@@ -1,19 +1,19 @@
-import { useRef } from 'react';
+import { useRef, FC } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Vector3, Mesh } from 'three';
 import { makeColorChangedMaterial } from '@utils/meshUtils';
 
 interface SnowProps {
   radius: number;
-  centerPosition: THREE.Vector3;
+  centerPosition: Vector3;
   rangeRadius: number;
   model: number;
 }
 
 const randomizePosition = (
-  target: THREE.Mesh,
-  centerPosition: THREE.Vector3,
+  target: Mesh,
+  centerPosition: Vector3,
   radius: number
 ) => {
   target.position.set(
@@ -24,9 +24,9 @@ const randomizePosition = (
 };
 
 const fallingAnimate = (
-  target: THREE.Mesh,
+  target: Mesh,
   speed: number,
-  centerPosition: THREE.Vector3,
+  centerPosition: Vector3,
   radius: number
 ) => {
   if (target.position.y <= -1) {
@@ -37,13 +37,13 @@ const fallingAnimate = (
   target.position.y -= speed;
 };
 
-const rotateAnimate = (target: THREE.Mesh, speed: number) => {
+const rotateAnimate = (target: Mesh, speed: number) => {
   target.rotation.y += speed;
 };
 
 const visibleInRange = (
-  target: THREE.Mesh,
-  centerPosition: THREE.Vector3,
+  target: Mesh,
+  centerPosition: Vector3,
   radius: number
 ) => {
   target.visible =
@@ -52,14 +52,14 @@ const visibleInRange = (
 
 const snowcolor = ['#99c9fd', '#a5bbd3', '#f1faff'];
 
-const Snow: React.FC<SnowProps> = ({
+const Snow: FC<SnowProps> = ({
   radius,
   centerPosition,
   rangeRadius,
   model
 }) => {
-  const snowRef = useRef<THREE.Mesh>(null);
-  const position = new THREE.Vector3(
+  const snowRef = useRef<Mesh>(null);
+  const position = new Vector3(
     centerPosition.x - rangeRadius + Math.random() * rangeRadius * 2,
     centerPosition.y + rangeRadius + Math.random() * rangeRadius * 2,
     centerPosition.z - rangeRadius + Math.random() * rangeRadius * 2
@@ -71,7 +71,7 @@ const Snow: React.FC<SnowProps> = ({
   snow.scale.set(radius, radius, radius);
   snow.rotation.y = Math.random();
   snow.traverse(obj => {
-    if (obj instanceof THREE.Mesh) {
+    if (obj instanceof Mesh) {
       obj.material = makeColorChangedMaterial(
         obj,
         snowcolor[Math.floor(Math.random() * 3)]

--- a/front/src/components/Song/Song.tsx
+++ b/front/src/components/Song/Song.tsx
@@ -41,6 +41,7 @@ const Song = () => {
     <StyledMusic
       id="musicController"
       src={play ? '/music/music.svg' : '/music/music-slash.svg'}
+      alt="music"
       onClick={toggle}
     />
   );

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -1,14 +1,14 @@
 import ReactDOM from 'react-dom/client';
-import * as Sentry from '@sentry/react';
+import { init, BrowserTracing, Replay } from '@sentry/react';
 import App from './App';
 
-Sentry.init({
+init({
   dsn: import.meta.env.VITE_APP_SENTRY_DSN,
   integrations: [
-    new Sentry.BrowserTracing({
+    new BrowserTracing({
       tracePropagationTargets: ['localhost', /^https:\/\/mysnowball\.kr\/api/]
     }),
-    new Sentry.Replay()
+    new Replay()
   ],
   tracesSampleRate: 1.0,
   replaysSessionSampleRate: 0.1,

--- a/front/src/pages/Make/Snowball/MainDeco/MakeSnowballCanvas.tsx
+++ b/front/src/pages/Make/Snowball/MainDeco/MakeSnowballCanvas.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
-import * as THREE from 'three';
+import { OrbitControls } from '@react-three/drei/core/OrbitControls';
+import { Vector3, Color } from 'three';
 import { CanvasContainer } from '@utils';
 import * as Models from '@components/SnowGlobeCanvas/models';
 import { DecoContext } from './DecoProvider';
@@ -22,24 +22,24 @@ const MainSnowballCavnas = () => {
           color={'#e2bb83'}
         />
         <Models.Glass
-          position={new THREE.Vector3(0, glassRadius / 2, 0)}
+          position={new Vector3(0, glassRadius / 2, 0)}
           radius={glassRadius}
-          color={new THREE.Color('white')}
+          color={new Color('white')}
           opacity={0.1}
         />
-        <Models.Ground scale={1} position={new THREE.Vector3(0, 0, 0)} />
+        <Models.Ground scale={1} position={new Vector3(0, 0, 0)} />
         <Models.MainDeco
           id={mainDecoID}
           scale={1}
-          position={new THREE.Vector3(0, 0, 0)}
+          position={new Vector3(0, 0, 0)}
           color={mainColor}
         />
         <Models.Bottom
           scale={1}
-          position={new THREE.Vector3(0, 0, 0)}
+          position={new Vector3(0, 0, 0)}
           bottomID={bottomID}
           title={snowballName}
-          color={new THREE.Color(bottomColor)}
+          color={new Color(bottomColor)}
         />
       </Canvas>
     </CanvasContainer>

--- a/front/src/pages/Visit/Deco/DecoCanvas/DecoCanvas.tsx
+++ b/front/src/pages/Visit/Deco/DecoCanvas/DecoCanvas.tsx
@@ -1,5 +1,5 @@
 import { Canvas } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
+import { OrbitControls } from '@react-three/drei/core/OrbitControls';
 import { CanvasContainer } from '@utils';
 import DecoModel from './DecoModel';
 

--- a/front/src/pages/Visit/Deco/DecoCanvas/DecoModel.tsx
+++ b/front/src/pages/Visit/Deco/DecoCanvas/DecoModel.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
-import { useGLTF } from '@react-three/drei';
-import * as THREE from 'three';
+import { useGLTF } from '@react-three/drei/core/useGLTF';
+import { Mesh } from 'three';
 import { makeColorChangedMaterial } from '@utils/meshUtils';
 import { DECO } from '@constants';
 import { DecoContext } from '../DecoProvider';
@@ -12,7 +12,7 @@ const DecoModel = () => {
   deco.scale.set(1.5, 1.5, 1.5);
   deco.position.set(0, 0, 0);
   deco.children.forEach(child => {
-    if (child instanceof THREE.Mesh) {
+    if (child instanceof Mesh) {
       if (child.name === 'Sub') {
         return;
       }

--- a/front/src/utils/axios.tsx
+++ b/front/src/utils/axios.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import * as Sentry from '@sentry/react';
+import { captureException } from '@sentry/react';
 
 const instance = axios.create();
 
@@ -8,7 +8,7 @@ instance.interceptors.response.use(
   error => {
     // 오류 처리
     if (error.response && error.response.status !== 409) {
-      Sentry.captureException(error);
+      captureException(error);
     }
     return Promise.reject(error);
   }

--- a/front/src/utils/index.tsx
+++ b/front/src/utils/index.tsx
@@ -2,4 +2,4 @@ export { default as theme } from './theme';
 export { CanvasContainer, Container, LongButton, BlurBody } from './styled';
 export { default as Loading } from './Loading';
 export { default as axios } from './axios';
-export { default as getDecoPoisition } from './position';
+export { default as getDecoPosition } from './position';

--- a/front/src/utils/meshUtils.tsx
+++ b/front/src/utils/meshUtils.tsx
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { Mesh, Material, MeshBasicMaterial, MeshStandardMaterial, CanvasTexture } from 'three';
 
 interface canvasMaterialProps {
   string: string;
@@ -10,14 +10,14 @@ interface canvasMaterialProps {
   backgGroundColor: string;
 }
 
-const makeColorChangedMaterial = (mesh: THREE.Mesh, color: string) => {
+const makeColorChangedMaterial = (mesh: Mesh, color: string) => {
   const newMaterial = (
-    mesh.material as THREE.Material
-  ).clone() as THREE.Material;
+    mesh.material as Material
+  ).clone() as Material;
 
   if (
-    newMaterial instanceof THREE.MeshBasicMaterial ||
-    newMaterial instanceof THREE.MeshStandardMaterial
+    newMaterial instanceof MeshBasicMaterial ||
+    newMaterial instanceof MeshStandardMaterial
   ) {
     newMaterial.color.set(color);
   }
@@ -50,7 +50,7 @@ const makeCanvasTexture = (props: canvasMaterialProps) => {
     canvas.width
   );
 
-  return new THREE.CanvasTexture(canvas);
+  return new CanvasTexture(canvas);
 };
 
 export { makeColorChangedMaterial, makeCanvasTexture };

--- a/front/src/utils/position.tsx
+++ b/front/src/utils/position.tsx
@@ -1,6 +1,6 @@
-import * as THREE from 'three';
+import { Vector3 } from "three";
 
-const getDecoPoisition = (n: number): THREE.Vector3 => {
+const getDecoPosition = (n: number): Vector3 => {
   const positions = [
     [0, 0],
     [1.5, -0.5],
@@ -34,7 +34,7 @@ const getDecoPoisition = (n: number): THREE.Vector3 => {
     [-2.5, -2.5],
     [-2.5, 2.5]
   ];
-  return new THREE.Vector3(positions[n][0], 0, positions[n][1]);
+  return new Vector3(positions[n][0], 0, positions[n][1]);
 };
 
-export default getDecoPoisition;
+export default getDecoPosition;

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import mkcert from 'vite-plugin-mkcert';
+import { compressNormals, compressPositions } from 'three/examples/jsm/utils/GeometryCompressionUtils.js';
+import { compression } from 'vite-plugin-compression2'
 
 export default defineConfig({
-  plugins: [react(), mkcert()],
+  plugins: [
+    react(),
+    mkcert(),
+
+  ],
   server: {
     host: '0.0.0.0',
     https: true,
@@ -25,5 +31,16 @@ export default defineConfig({
       '@utils': '/src/utils',
       '@mock': '/src/mockdata.json'
     }
-  }
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          three : ['three'],
+          'three-fiber' : ['@react-three/fiber'],
+          'three-drei' : ['@react-three/drei'],
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 💡 완료된 기능
- [x] build 된 JS 소스 코드 파일 분리
- [x] lighthouse 검색엔진 최적화 및 접근성 점수 향상
- [x] 초기 로딩 속도 향상
 
라이브러리 import 시 사용하는 함수나 클래스만 import 할수 있도록 수정하였습니다.

three.js 의 경우 코드 셰이킹이 적용되지 않아 여전히 높은 청크를 유지하고 있습니다.

웹 페이지 초기 로딩속도의 경우 약 `40%` 향상 시켜주었지만, 여전히 낮은 성능을 보이고 있습니다.



## 📷 완료된 기능 사진

![스크린샷 2024-01-08 222907](https://github.com/boostcampwm2023/web11-SSOCK/assets/98443541/53bf6475-e789-4a22-b64f-62c47744812a)


![스크린샷 2024-01-08 222935](https://github.com/boostcampwm2023/web11-SSOCK/assets/98443541/9082943f-6de6-4e17-b478-94df785751f7)


![스크린샷 2024-01-08 223041](https://github.com/boostcampwm2023/web11-SSOCK/assets/98443541/73b5459f-5795-4ee3-b23f-bd08bb243864)

![스크린샷 2024-01-08 222952](https://github.com/boostcampwm2023/web11-SSOCK/assets/98443541/b9c620ed-77d0-4317-83ba-27982215f8aa)

![스크린샷 2024-01-08 224219](https://github.com/boostcampwm2023/web11-SSOCK/assets/98443541/d7aabdd9-3cd8-4822-8402-90d613f28da5)

![스크린샷 2024-01-08 224231](https://github.com/boostcampwm2023/web11-SSOCK/assets/98443541/a91d96b7-deb5-4a7c-b850-bdc4bd9303e0)

